### PR TITLE
fixed positive modifiers not sending to Talespire

### DIFF
--- a/vault.js
+++ b/vault.js
@@ -205,7 +205,7 @@ function constructDiceRollString(diceCounts) {
     
     if (diceCounts.mod !== '0') {
         let modValue = parseInt(diceCounts.mod, 10);
-        let modPart = modValue >= 0 ? `+${modValue}` : `${modValue}`;
+        let modPart = modValue >= 0 ? `${modValue}` : `${modValue}`;
         diceRollParts.push(modPart);
     }
 


### PR DESCRIPTION
Fixing positive modifers not sending to Talespire. The bug was that adding + to the string seemed to break it so it seems to translate properly the positive or negative integer now without the + sign. I tested locally and saw both +1 and -1 working with a d6 roll