### PR TITLE
adding additional sorting

### DIFF
--- a/vault.html
+++ b/vault.html
@@ -95,6 +95,8 @@
                     <select id="sort-options" onchange="sortSavedRolls()">
                         <option value="newest">Newest</option>
                         <option value="oldest">Oldest</option>
+                        <option value="nameAsc">Sort A-Z</option>
+                        <option value="nameDesc">Sort Z-A</option>
                     </select>
                 </div>
             </div>

--- a/vault.js
+++ b/vault.js
@@ -58,6 +58,12 @@ function sortSavedRolls() {
         case 'newest':
             savedRollsToDisplay.reverse();
             break;
+        case 'nameAsc':
+            savedRollsToDisplay.sort((a, b) => a.querySelector('.roll-entry-label').textContent.localeCompare(b.querySelector('.roll-entry-label').textContent));
+            break;
+        case 'nameDesc':
+            savedRollsToDisplay.sort((a, b) => b.querySelector('.roll-entry-label').textContent.localeCompare(a.querySelector('.roll-entry-label').textContent));
+            break;
         case 'all':
             break;
     }


### PR DESCRIPTION
This PR adds 2 additional sorting options which we used to have but recently removed as part of the redesign in the saved roll cards.

The sorting dropdown now has sorting alphabetically A-Z and Z-A.

Full sort list is now:
- Newest
- Oldest
- Sort A-Z
- Sort Z-A