### PR TITLE
Options Menu + Save/Load Improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,9 @@
     "subscriptions": {
       "dice": {
         "onRollResults": "handleRollResult"
+      },
+      "symbiote": {
+        "onStateChangeEvent": "onStateChangeEvent"
       }
     }
   },

--- a/vault.css
+++ b/vault.css
@@ -261,7 +261,7 @@ h1 {
 }
 
 
-#sort-options {
+.select-list {
     padding: 8px 16px; 
     margin-left: 10px; 
     border: 2px solid var(--ts-color-primary); 
@@ -280,13 +280,13 @@ h1 {
     position: relative;
 }
 
-#sort-options:hover {
+.select-list:hover {
     background-color: var(--ts-button-hover); 
     border-color: var(--ts-color-secondary); 
 }
 
 
-#sort-options::-ms-expand {
+.select-list::-ms-expand {
     display: none; 
 }
 

--- a/vault.css
+++ b/vault.css
@@ -10,6 +10,36 @@ html, body {
     user-select: none;
 }
 
+#menu-bar{
+    padding: 5px;
+}
+
+#settings-button{
+    width: 38px;
+    height: 38px;
+    padding-bottom: 15px;
+    background-color: black;
+    color: rgb(0, 0, 0);
+    border-radius: 50%;
+}
+
+#settings-menu{
+    display: block;
+    background-color: var(--ts-background-primary);
+    border: 1px solid var(--ts-accessibility-border);
+    border-radius: 4px;
+    margin: 20px;
+    z-index: 1;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.active-menu{
+    background-color: grey !important;
+}
+
 .content {
     overflow: hidden;
     display: flex;

--- a/vault.css
+++ b/vault.css
@@ -60,7 +60,7 @@ html, body {
     gap: 10px;
 }
 
-#save-rolls-button, #load-rolls-button {
+.black-button {
     padding: 5px 15px;
     margin: 5px;
     border: 1px solid #ccc;
@@ -70,9 +70,20 @@ html, body {
     cursor: pointer;
 }
 
-#save-rolls-button:hover, #load-rolls-button:hover {
-    background-color: var(--ts-button-hover); 
+.black-button:hover {
+    background-color: var(--ts-button-hover);
     color: #000000;
+}
+
+.black-button:active {
+    background-color: var(--ts-button-background);
+    color: #000000;
+}
+
+.black-button:disabled, .black-button:disabled:hover{
+    background-color: var(--ts-background-primary);
+    color: var(--ts-color-secondary);
+    cursor: not-allowed;
 }
 
 .unsaved-changes{

--- a/vault.css
+++ b/vault.css
@@ -75,6 +75,11 @@ html, body {
     color: #000000;
 }
 
+.unsaved-changes{
+    background-color: var(--ts-background-tertiary) !important;
+    color: var(--ts-accent-hover) !important;
+}
+
 marquee {
     font-size: 18px;
     padding: 10px;

--- a/vault.html
+++ b/vault.html
@@ -7,6 +7,27 @@
 
     <body>
         <div class="content">
+            <div id="menu-bar">
+                <i class="ts-icon-gear" id="settings-button" onclick="toggleSettingsDisplay()"></i>
+            </div>
+            <div id="settings-menu" class="hidden">
+                <hr/>
+                <table>
+                    <tr>
+                        <td><label class="field-title">Auto-Load Saved Rolls</label></td>
+                        <td><input type="checkbox" id="auto-load" class="settings-input" onchange="saveGlobalSettings()" unchecked></td>
+                    </tr>
+                    <tr>
+                        <td><label class="field-title">Auto-Save Saved Rolls</label></td>
+                        <td><input type="checkbox" id="auto-save" class="settings-input" onchange="saveGlobalSettings()" unchecked></td>
+                    </tr>
+                    <tr>
+                        <td><label class="field-title">Auto-Reset Edit on Save</label></td>
+                        <td><input type="checkbox" id="auto-reset" class="settings-input"onchange="saveGlobalSettings()" unchecked></td>
+                    </tr>
+                </table>
+                <hr/>
+            </div>
             <div style="text-align: center; margin-top: 0;">
                 <img src="images/DiceVault.png" alt="Dice Vault - Secure your fate with a roll" style="max-width: 20%">
                 <h1 style="position: absolute; overflow: hidden; clip: rect(0 0 0 0); height: 1px; width: 1px; margin: -1px; padding: 0; border: 0;">

--- a/vault.html
+++ b/vault.html
@@ -127,11 +127,11 @@
         </div>
 
         <div class="footer">
-            <button id="save-rolls-button">Save Rolls</button>
+            <button id="save-rolls-button" class="black-button">Save Rolls</button>
             
             <i class="ts-icon-character-gamemaster"></i><div style="font-family: 'Enchanted Land', cursive; color: #dddddd; font-size: 0.7em;"> "May the rolls be in your favor"</div>
 
-            <button id="load-rolls-button">Load Rolls</button>
+            <button id="load-rolls-button" class="black-button">Load Rolls</button>
         </div>
 
         <script type="text/javascript" src="vault.js"></script>

--- a/vault.html
+++ b/vault.html
@@ -22,7 +22,7 @@
                         <td><input type="checkbox" id="auto-save" class="settings-input" onchange="saveGlobalSettings()" unchecked></td>
                     </tr>
                     <tr>
-                        <td><label class="field-title">Auto-Reset Edit on Save</label></td>
+                        <td><label class="field-title">Auto-Reset Dice on Save</label></td>
                         <td><input type="checkbox" id="auto-reset" class="settings-input"onchange="saveGlobalSettings()" unchecked></td>
                     </tr>
                 </table>

--- a/vault.html
+++ b/vault.html
@@ -113,7 +113,7 @@
             <div class="saved-rolls-header">
                 <label class="field-title">Saved Rolls</label>
                 <div id="sort-options-container">
-                    <select id="sort-options" onchange="sortSavedRolls()">
+                    <select id="sort-options" class='select-list' onchange="sortSavedRolls()">
                         <option value="newest">Newest</option>
                         <option value="oldest">Oldest</option>
                         <option value="nameAsc">Sort A-Z</option>

--- a/vault.js
+++ b/vault.js
@@ -309,6 +309,46 @@ async function displayResult(resultGroup, rollId) {
     TS.dice.sendDiceResult([resultGroup], rollId).catch((response) => console.error("error in sending dice result", response));
 }
 
+function toggleSettingsDisplay() {
+    const settingsContainer = document.querySelector('#settings-menu');
+    const settingsButton = document.querySelector('#settings-button');
+    settingsContainer.classList.toggle('hidden');
+    settingsButton.classList.toggle('active-menu');
+}
+
+function defaultSettings(settingName){
+    const settings = {
+        autoLoadRolls: false,
+        autoSaveRolls: false,
+        autoResetEdit: false
+    }
+    return settings[settingName];
+}
+
+function saveGlobalSettings(){
+    const settings = {
+        autoLoadRolls: document.getElementById('auto-load').checked,
+        autoSaveRolls: document.getElementById('auto-save').checked,
+        autoResetEdit: document.getElementById('auto-reset').checked
+    }
+    TS.localStorage.global.setBlob(JSON.stringify(settings)).then(() => {
+        console.log('Settings saved successfully.');
+    }).catch(error => {
+        console.error('Failed to save settings:', error);
+    });
+}
+
+function loadGlobalSettings(){
+    TS.localStorage.global.getBlob().then(settingsJson => {
+        const settings = JSON.parse(settingsJson || '{}');
+        document.getElementById('auto-load').checked = settings.autoLoadRolls || defaultSettings('autoLoadRolls');
+        document.getElementById('auto-save').checked = settings.autoSaveRolls || defaultSettings('autoSaveRolls');
+        document.getElementById('auto-reset').checked = settings.autoSaveRolls || defaultSettings('autoResetEdit');
+    }).catch(error => {
+        console.error('Failed to load settings:', error);
+    });
+}
+
 function saveRollsToLocalStorage() {
     let rollsData = [];
     document.querySelectorAll('.saved-roll-entry').forEach(entry => {
@@ -340,5 +380,12 @@ function loadRollsFromLocalStorage() {
         console.error('Failed to load rolls data:', error);
     });
 }
+
+async function onStateChangeEvent(msg){
+    if (msg.kind === 'hasInitialized'){
+        loadGlobalSettings();
+    }
+}
+
 document.getElementById('save-rolls-button').addEventListener('click', saveRollsToLocalStorage);
 document.getElementById('load-rolls-button').addEventListener('click', loadRollsFromLocalStorage);

--- a/vault.js
+++ b/vault.js
@@ -363,6 +363,10 @@ function fetchSetting(settingName){
     if (setting.type === 'checkbox'){
         return setting.checked;
     }
+
+    if (setting.type === 'select-one'){
+        return setting.value;
+    }
 }
 
 function saveRollsToLocalStorage() {

--- a/vault.js
+++ b/vault.js
@@ -95,6 +95,10 @@ function save() {
 
     addSavedRoll(rollName, selectedType, diceCounts);
     saveCurrentRolls();
+
+    if (fetchSetting('auto-reset')){
+        reset();
+    }
 }
 
 function addSavedRoll(rollName, rollType, diceCounts) {
@@ -347,6 +351,18 @@ function loadGlobalSettings(){
     }).catch(error => {
         console.error('Failed to load settings:', error);
     });
+}
+
+function fetchSetting(settingName){
+    const setting = document.getElementById(settingName)
+    if (setting === null){
+        console.error('Setting not found:', settingName);
+        return;
+    }
+
+    if (setting.type === 'checkbox'){
+        return setting.checked;
+    }
 }
 
 function saveRollsToLocalStorage() {

--- a/vault.js
+++ b/vault.js
@@ -80,7 +80,8 @@ function deleteSavedRoll(element) {
     if (fetchSetting('auto-save')) {
         saveRollsToLocalStorage();
     }else{
-        document.getElementById('save-rolls-button').classList.add('unsaved-changes');
+        disableButtonById('load-rolls-button', false);
+        disableButtonById('save-rolls-button', false);
     }
 }
 
@@ -109,7 +110,7 @@ function save() {
     if (fetchSetting('auto-save')){
         saveRollsToLocalStorage();
     }else{
-        document.getElementById('save-rolls-button').classList.add('unsaved-changes');
+        disableButtonById('save-rolls-button', false);
     }
 }
 
@@ -397,7 +398,8 @@ function saveRollsToLocalStorage() {
     console.log('Saving rolls data:', rollsJson); 
     TS.localStorage.campaign.setBlob(rollsJson).then(() => {
         console.log('Rolls data saved successfully.');
-        document.getElementById('save-rolls-button').classList.remove('unsaved-changes');
+        disableButtonById('save-rolls-button');
+        disableButtonById('load-rolls-button')
     }).catch(error => {
         console.error('Failed to save rolls data:', error);
     });
@@ -410,6 +412,10 @@ function loadRollsFromLocalStorage() {
         rollsData.forEach(rollData => {
             addSavedRoll(rollData.name, rollData.type, rollData.counts);
         });
+        disableButtonById('load-rolls-button');
+        if (!fetchSetting('auto-save')){
+            disableButtonById('save-rolls-button', false);
+        }
     }).catch(error => {
         console.error('Failed to load rolls data:', error);
     });
@@ -425,7 +431,16 @@ function performAutoLoads(){
     if (fetchSetting('auto-load')) {
         console.log('Auto-loading rolls from local storage.');
         loadRollsFromLocalStorage();
+        disableButtonById('load-rolls-button');
     }
+
+    if (fetchSetting('auto-save')) {
+        disableButtonById('save-rolls-button');
+    }
+}
+
+function disableButtonById(id, disable = true){
+    document.getElementById(id).disabled = disable;
 }
 
 document.getElementById('save-rolls-button').addEventListener('click', saveRollsToLocalStorage);

--- a/vault.js
+++ b/vault.js
@@ -76,6 +76,12 @@ function deleteSavedRoll(element) {
     const rollEntry = element.closest('.saved-roll-entry');
     rollEntry.remove();
     allSavedRolls = allSavedRolls.filter(roll => roll !== rollEntry);
+
+    if (fetchSetting('auto-save')) {
+        saveRollsToLocalStorage();
+    }else{
+        document.getElementById('save-rolls-button').classList.add('unsaved-changes');
+    }
 }
 
 document.addEventListener('DOMContentLoaded', sortSavedRolls);
@@ -98,6 +104,12 @@ function save() {
 
     if (fetchSetting('auto-reset')){
         reset();
+    }
+
+    if (fetchSetting('auto-save')){
+        saveRollsToLocalStorage();
+    }else{
+        document.getElementById('save-rolls-button').classList.add('unsaved-changes');
     }
 }
 
@@ -314,8 +326,8 @@ async function displayResult(resultGroup, rollId) {
 }
 
 function toggleSettingsDisplay() {
-    const settingsContainer = document.querySelector('#settings-menu');
-    const settingsButton = document.querySelector('#settings-button');
+    const settingsContainer = document.getElementById('settings-menu');
+    const settingsButton = document.getElementById('settings-button');
     settingsContainer.classList.toggle('hidden');
     settingsButton.classList.toggle('active-menu');
 }
@@ -385,6 +397,7 @@ function saveRollsToLocalStorage() {
     console.log('Saving rolls data:', rollsJson); 
     TS.localStorage.campaign.setBlob(rollsJson).then(() => {
         console.log('Rolls data saved successfully.');
+        document.getElementById('save-rolls-button').classList.remove('unsaved-changes');
     }).catch(error => {
         console.error('Failed to save rolls data:', error);
     });

--- a/vault.js
+++ b/vault.js
@@ -353,6 +353,7 @@ function saveGlobalSettings(){
     }).catch(error => {
         console.error('Failed to save settings:', error);
     });
+    updateAutoButtons();
 }
 
 function loadGlobalSettings(){
@@ -431,11 +432,31 @@ function performAutoLoads(){
     if (fetchSetting('auto-load')) {
         console.log('Auto-loading rolls from local storage.');
         loadRollsFromLocalStorage();
-        disableButtonById('load-rolls-button');
+
     }
 
     if (fetchSetting('auto-save')) {
+
+    }
+
+    updateAutoButtons();
+}
+
+function updateAutoButtons(){
+    if (fetchSetting('auto-load')) {
+        document.getElementById('load-rolls-button').innerText = 'Auto-Loading';
+        disableButtonById('load-rolls-button');
+    }else{
+        document.getElementById('load-rolls-button').innerText = 'Load Rolls';
+        disableButtonById('load-rolls-button', false);
+    }
+
+    if (fetchSetting('auto-save')) {
+        document.getElementById('save-rolls-button').innerText = 'Auto-Saving';
         disableButtonById('save-rolls-button');
+    } else {
+        document.getElementById('save-rolls-button').innerText = 'Save Rolls';
+        disableButtonById('save-rolls-button', false);
     }
 }
 

--- a/vault.js
+++ b/vault.js
@@ -348,6 +348,7 @@ function loadGlobalSettings(){
         document.getElementById('auto-load').checked = settings.autoLoadRolls || defaultSettings('autoLoadRolls');
         document.getElementById('auto-save').checked = settings.autoSaveRolls || defaultSettings('autoSaveRolls');
         document.getElementById('auto-reset').checked = settings.autoSaveRolls || defaultSettings('autoResetEdit');
+        performAutoLoads();
     }).catch(error => {
         console.error('Failed to load settings:', error);
     });
@@ -404,6 +405,13 @@ function loadRollsFromLocalStorage() {
 async function onStateChangeEvent(msg){
     if (msg.kind === 'hasInitialized'){
         loadGlobalSettings();
+    }
+}
+
+function performAutoLoads(){
+    if (fetchSetting('auto-load')) {
+        console.log('Auto-loading rolls from local storage.');
+        loadRollsFromLocalStorage();
     }
 }
 


### PR DESCRIPTION
Resolves #28 

Went with disabling/enabling Save/Load buttons rather than an "unsaved changes" state.

Logic behind each is as follows, if something doesn't sit right we can change:

If Auto-Save is turned on:
- Save button is disabled
If Auto-Save is turned off:
- Save button is disabled when a save is perfomed
- Save button is enabled when a load is performed
- Save button is enabled when a roll is deleted
- Save button is enabled when a new roll is saved

If Auto-Load is turned on:
- Load button is disabled
If Auto-Load is turned off:
- Load button is disabled when a load is performed
- Load button is disabled when a save is performed
- Load button is enabled when a roll is deleted

Decided not to change iconography with this PR. Will be part of overall iconography update.