### PR TITLE
1.4: Apply Roll Types to Roll Groups

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,27 +4,39 @@ The Dice Vault symbiote uses the following JavaScript files to deliver all of it
 
 ## diceCrits.js
 
-< write description >
+The `diceCrits.js` file is dedicated to handling critical hit logic within the Dice Vault symbiote. It defines the rules and behaviors for determining and applying critical hits during dice rolls, including the calculation of enhanced effects or bonuses when certain conditions are met. This file ensures that critical hits are consistently applied across all dice roll operations, enhancing the gameplay experience by adding an extra layer of excitement and unpredictability to the outcomes.
 
 ## globals.js
 
-< write description >
+The `globals.js` file serves as the foundation for the Dice Vault symbiote by defining and managing global variables and constants that are essential across the application. This includes configurations, state variables, and utility functions that need to be accessed by multiple components or scripts within the Dice Vault.
 
 ## rolls.js
 
-< write description >
+The `rolls.js` file is a core component of the Dice Vault symbiote, responsible for managing and executing dice roll operations. It defines the logic for initiating rolls, calculating results based on predefined rules, and handling different types of rolls such as standard, advantage, disadvantage, and custom roll types. Additionally, this file may include functions for interpreting roll results and integrating them with other features of the Dice Vault, ensuring a seamless dice rolling experience within the application.
 
 ## saveLoad.js
 
-< write description >
+The `saveLoad.js` file is integral to the Dice Vault symbiote, focusing on the persistence of user data and application state. It encapsulates the functionality for saving user configurations, dice roll histories, and any other relevant state information to a persistent storage medium. Additionally, it handles the loading of this data upon application startup or as needed, ensuring that users can seamlessly continue from where they left off.
 
 ## settings.js
 
-< write description >
+The `settings.js` file is dedicated to managing the configuration settings of the Dice Vault symbiote. It provides mechanisms for storing, retrieving, and updating user preferences and application settings. This includes options for dice roll behavior, visual themes, and other customizable features that enhance user interaction with the Dice Vault.
 
 ## vault.js
 
-< write description >
+The `vault.js` file acts as the central repository and interface for the Dice Vault symbiote, managing the collection of dice, roll types, and user-defined roll configurations. It provides a structured way to access and manipulate the dice and roll settings, facilitating the creation, storage, and retrieval of custom dice combinations and roll logic. This file ensures that all dice-related operations are efficiently handled and easily accessible, supporting the dynamic needs of users for customizing their dice rolling experience.
+
+# Design Patterns & Coding Conventions
+
+This symbiote uses the following design patterns and coding conventions.
+
+## Revealing Module Pattern
+
+The Revealing Module Pattern for JavaScript is variant of the Module Pattern, in which we create a regular JavaScript module, but then we "reveal" public pointers to functions inside the module's scope. This creates a nice code management system in which you can clearly see which functions are meant to be used outside the module and which functions are only meant for the module's internal scope. This is one of the primary attractions of the Module and Revealing Module patterns, as they both make scoping a breeze without overcomplicating code and application design.
+
+**References**
+
+-   [Mastering the Module Pattern](https://ultimatecourses.com/blog/mastering-the-module-pattern)
 
 # TaleSpire API Notes
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,180 @@
+# Scripts
+
+The Dice Vault symbiote uses the following JavaScript files to deliver all of its features.
+
+## diceCrits.js
+
+< write description >
+
+## globals.js
+
+< write description >
+
+## rolls.js
+
+< write description >
+
+## saveLoad.js
+
+< write description >
+
+## settings.js
+
+< write description >
+
+## vault.js
+
+< write description >
+
+# TaleSpire API Notes
+
+## Example of rollDescriptor Array
+
+[rollDescriptor](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rolldescriptor)
+
+```
+[
+    {
+        "name": "test-4-groups",
+        "roll": "+1d4+1d6"
+    },
+    {
+        "name": "test-4-groups",
+        "roll": "+1d4+1d6+50"
+    },
+    {
+        "name": "test-4-groups",
+        "roll": "+1d6+1d8+100"
+    },
+    {
+        "name": "test-4-groups",
+        "roll": "+1d8+1d10+200"
+    }
+]
+```
+
+## Example RollEvent Object
+
+[onRollResults](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#subscriptions/dice/onrollresults)
+
+[rollResults](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollresults)
+
+[rollRemoved](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollremoved)
+
+```
+{
+    "kind": "rollResults",
+    "payload": {
+        "rollId": "17179869185",
+        "clientId": "e0a85890-68af-4cc2-b55b-e11d12b89889",
+        "resultsGroups": [
+            {
+                "name": "test-4-groups",
+                "result": {
+                    "operator": "+",
+                    "operands": [
+                        {
+                            "kind": "d4",
+                            "results": [
+                                3
+                            ]
+                        },
+                        {
+                            "kind": "d6",
+                            "results": [
+                                4
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "test-4-groups",
+                "result": {
+                    "operator": "+",
+                    "operands": [
+                        {
+                            "kind": "d4",
+                            "results": [
+                                1
+                            ]
+                        },
+                        {
+                            "operator": "+",
+                            "operands": [
+                                {
+                                    "kind": "d6",
+                                    "results": [
+                                        4
+                                    ]
+                                },
+                                {
+                                    "value": 50
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "test-4-groups",
+                "result": {
+                    "operator": "+",
+                    "operands": [
+                        {
+                            "kind": "d6",
+                            "results": [
+                                1
+                            ]
+                        },
+                        {
+                            "operator": "+",
+                            "operands": [
+                                {
+                                    "kind": "d8",
+                                    "results": [
+                                        1
+                                    ]
+                                },
+                                {
+                                    "value": 100
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "name": "test-4-groups",
+                "result": {
+                    "operator": "+",
+                    "operands": [
+                        {
+                            "kind": "d8",
+                            "results": [
+                                4
+                            ]
+                        },
+                        {
+                            "operator": "+",
+                            "operands": [
+                                {
+                                    "kind": "d10",
+                                    "results": [
+                                        5
+                                    ]
+                                },
+                                {
+                                    "value": 200
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ],
+        "gmOnly": false,
+        "quiet": true
+    }
+}
+```

--- a/scripts/diceCrits.js
+++ b/scripts/diceCrits.js
@@ -1,26 +1,14 @@
-// function doubleDieCounts(diceCounts) {
-//     let newDiceCounts = {};
-//     for (const [die, count] of Object.entries(diceCounts)) {
-//         if (die !== 'mod') {
-//             newDiceCounts[die] = String(parseInt(count, 10) * 2);
-//         } else {
-//             newDiceCounts[die] = count;
-//         }
-//     }
-//     return newDiceCounts;
-// }
-
-function doubleDieCountsForGroups(stagedRollGroups) {
-    return stagedRollGroups.map(diceCounts => {
-        let newDiceCounts = {};
+function doubleDiceCounts(rollGroups) {
+    return rollGroups.map(diceCounts => {
+        let doubledDiceCounts = {};
         for (const [die, count] of Object.entries(diceCounts)) {
             if (die !== 'mod') {
-                newDiceCounts[die] = String(parseInt(count, 10) * 2);
+                doubledDiceCounts[die] = String(parseInt(count, 10) * 2);
             } else {
-                newDiceCounts[die] = count;
+                doubledDiceCounts[die] = count;
             }
         }
-        return newDiceCounts;
+        return doubledDiceCounts;
     });
 }
 

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -1,7 +1,7 @@
 let savedInVault = []; // Array of arrays, contains diceGroupsData[] arrays as elements which is everything saved to JSON ./localstorage/ inside one array
 let diceGroupsData = []; // Array of objects, contains the dice groups that are currently being rolled
 let savedDiceGroups = []; // MOVE to globals.js
-let trackedIds = {}; // MOVE to globals.js
+let trackedRollIds = {}; // MOVE to globals.js
 const diceTypes = ["d4", "d6", "d8", "d10", "d12", "d20"]; // Array containing all dice denominations that exist
 
 const rollTypes = Object.freeze({

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -1,9 +1,40 @@
-let savedInVault = []; // Array of arrays, contains diceGroupsData[] arrays as elements which is everything saved to JSON ./localstorage/ inside one array
-let diceGroupsData = []; // Array of objects, contains the dice groups that are currently being rolled
-let savedDiceGroups = []; // MOVE to globals.js
-let trackedRollIds = {}; // MOVE to globals.js
-const diceTypes = ["d4", "d6", "d8", "d10", "d12", "d20"]; // Array containing all dice denominations that exist
+/**
+ * Array of arrays, contains diceGroupsData[] arrays as elements which is
+ * everything saved to JSON ./localstorage/ inside one array.
+ */
+let savedInVault = [];
 
+/**
+ * Array of objects, contains the dice groups that are currently being rolled.
+ */
+let diceGroupsData = [];
+
+/**
+ * Array of objects, contains the saved dice groups.
+ */
+let savedDiceGroups = [];
+
+/**
+ * Array of objects, contains the active set of dice rolls being tracked by
+ * the symbiote.
+ */
+let trackedRollIds = {};
+
+/**
+ * Array containing all dice denominations that exist.
+ */
+const diceTypes = ["d4", "d6", "d8", "d10", "d12", "d20"];
+
+/**
+ * Defines the available roll types for dice operations. The available roll
+ * types include:
+ *
+ * - normal: A standard roll without any modifiers.
+ * - advantage: Roll multiple dice and take the highest result.
+ * - disadvantage: Roll multiple dice and take the lowest result.
+ * - bestofThree: Roll three dice and take the best result.
+ * - critical: A critical roll, often leading to enhanced effects or outcomes.
+ */
 const rollTypes = Object.freeze({
     normal: "normal",
     advantage: "advantage",
@@ -12,6 +43,13 @@ const rollTypes = Object.freeze({
     critical: "crit-dice",
 });
 
+/**
+ * Defines a set of event types related to dice roll operations. The defined
+ * event types include:
+ *
+ * - `rollResults`: Emitted when dice roll results are available.
+ * - `rollRemoved`: Emitted when a dice roll is removed from consideration or display.
+ */
 const rollEvents = Object.freeze({
     rollResults: "rollResults",
     rollRemoved: "rollRemoved",

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -11,3 +11,8 @@ const rollTypes = Object.freeze({
     bestofThree: "best-of-three",
     critical: "crit-dice",
 });
+
+const rollEvents = Object.freeze({
+    rollResults: "rollResults",
+    rollRemoved: "rollRemoved",
+});

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -1,3 +1,11 @@
 let savedInVault = []; // Array of arrays, contains diceGroupsData[] arrays as elements which is everything saved to JSON ./localstorage/ inside one array
 let diceGroupsData = []; // Array of objects, contains the dice groups that are currently being rolled
-const diceTypes = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20']; // Array containing all dice denominations that exist
+const diceTypes = ["d4", "d6", "d8", "d10", "d12", "d20"]; // Array containing all dice denominations that exist
+
+const rollTypes = Object.freeze({
+    normal: "normal",
+    advantage: "advantage",
+    disadvantage: "disadvantage",
+    bestofThree: "best-of-three",
+    critical: "crit-dice",
+});

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -54,9 +54,8 @@ const rollsModule = (function () {
         // Adjust for critical hit dice types
         if (selectedType === rollTypes.critical) {
             if (critBehavior === "double-die-count") {
-                diceCounts = doubleDieCountsForGroups(group); // TODO: This doesn't work. Hasn't been implemented yet.
+                diceGroupsData = doubleDiceCounts(diceGroupsData);
             }
-            selectedType = rollTypes.normal; // Reset to normal type after handling critical dice
         } else {
             critBehavior = "none";
         }
@@ -175,6 +174,7 @@ const rollsModule = (function () {
      * @returns {string} The constructed roll name, combining the base name, roll type,
      *                   and critical hit behavior.
      */
+
     function buildRollName(rollNameParam, rollTypeParam, critBehaviorParam) {
         let rollName =
             rollNameParam ||
@@ -293,7 +293,7 @@ const rollsModule = (function () {
      * @returns {Promise<void>} A promise that resolves once the roll event has been processed.
      */
     async function handleRollResult(rollEvent) {
-        if (trackedRollIds[rollEvent.payload.rollId] == undefined) {
+        if (trackedRollIds[rollEvent.payload.rollId] == undefined) { // BUG: for some reason we are losing the rollId. We have it when we enter but when we evaluate this we flip to undefined then enter the failure condition
             console.error(
                 `Tracked Roll for ID \"${rollEvent.payload.rollId}\" not found.`
             );

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -1,5 +1,3 @@
-let trackedRollIds = {};
-
 function roll(rollNameParam, rollTypeParam) {
     let selectedType = rollTypeParam || rollTypes.normal; // Set to normal if no type is provided
     let updatedDiceGroupsData = []; // Empty the array to purge old data. We call this "updated" temporarily, but it will become the new diceGroupsData

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -364,7 +364,7 @@ async function handleRollResultsEvent(rollEvent) {
     if (roll.resultsGroups != undefined) {
         let rollInfo = trackedRollIds[roll.rollId];
 
-        resultGroup = getReportableRollResultsGroup(roll, rollInfo.type);
+        resultGroup = await getReportableRollResultsGroup(roll, rollInfo.type);
 
         resultGroup = applyCritBehaviorToRollResultsGroup(
             resultGroup,
@@ -622,7 +622,7 @@ function applyCritBehaviorToRollResultsGroup(resultGroup, critBehavior) {
  * @returns {Promise<void>} A promise that resolves when the dice result has been
  *                          successfully sent or logs an error upon failure.
  */
-async function displayResult(resultGroup, rollId) {
+function displayResult(resultGroup, rollId) {
     TS.dice
         .sendDiceResult(resultGroup, rollId)
         .catch((response) =>

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -1,631 +1,659 @@
-/**
- * Executes a dice roll operation based on specified roll name and type.
- * Places the dice to roll into TaleSpire's dice tray for displaying and
- * rolling in the game.
- *
- * @param {string} rollNameParam - The name of the roll, which may be used for
- *                                 display or logging purposes.
- * @param {string} rollTypeParam - The type of the roll (e.g., 'normal', 'critical'),
- *                                 which influences how the dice are rolled.
- */
-function roll(rollNameParam, rollTypeParam) {
-    let selectedType = rollTypeParam || rollTypes.normal; // Set to normal if no type is provided
-    let updatedDiceGroupsData = []; // Empty the array to purge old data. We call this "updated" temporarily, but it will become the new diceGroupsData
+const rollsModule = (function () {
+    /**
+     * Executes a dice roll operation based on specified roll name and type.
+     * Places the dice to roll into TaleSpire's dice tray for displaying and
+     * rolling in the game.
+     *
+     * @param {string} rollNameParam - The name of the roll, which may be used for
+     *                                 display or logging purposes.
+     * @param {string} rollTypeParam - The type of the roll (e.g., 'normal', 'critical'),
+     *                                 which influences how the dice are rolled.
+     */
+    function roll(rollNameParam, rollTypeParam) {
+        let selectedType = rollTypeParam || rollTypes.normal; // Set to normal if no type is provided
+        let updatedDiceGroupsData = []; // Empty the array to purge old data. We call this "updated" temporarily, but it will become the new diceGroupsData
 
-    // TODO: CONSIDER MOVING THIS TO A SEPARATE FUNCTION
-    // buildDiceGroupsData(diceGroupsData);
-    // return updatedDiceGroupsData;
-    diceGroupsData.forEach((group, index) => {
-        let groupId = index;
-        let groupDiceCounts = {};
-        diceTypes.forEach((type) => {
-            const counter = document.getElementById(
-                `${groupId}-${type}-counter-value`
+        // TODO: CONSIDER MOVING THIS TO A SEPARATE FUNCTION
+        // buildDiceGroupsData(diceGroupsData);
+        // return updatedDiceGroupsData;
+        diceGroupsData.forEach((group, index) => {
+            let groupId = index;
+            let groupDiceCounts = {};
+            diceTypes.forEach((type) => {
+                const counter = document.getElementById(
+                    `${groupId}-${type}-counter-value`
+                );
+                if (counter) {
+                    groupDiceCounts[type] = counter.textContent;
+                } else {
+                    console.error(
+                        `Could not find counter for ${groupId}-${type}`
+                    );
+                }
+            });
+
+            const modCounter = document.getElementById(
+                `${groupId}-mod-counter-value`
             );
-            if (counter) {
-                groupDiceCounts[type] = counter.textContent;
+            if (modCounter) {
+                groupDiceCounts["mod"] = modCounter.value;
             } else {
-                console.error(`Could not find counter for ${groupId}-${type}`);
+                console.error(`Could not find mod counter for ${groupId}`);
             }
+
+            updatedDiceGroupsData.push(groupDiceCounts);
         });
 
-        const modCounter = document.getElementById(
-            `${groupId}-mod-counter-value`
-        );
-        if (modCounter) {
-            groupDiceCounts["mod"] = modCounter.value;
+        diceGroupsData = updatedDiceGroupsData; // Update the diceGroupsData with the new data
+
+        // TODO: CONSIDER MOVING THIS TO A SEPARATE FUNCTION
+        // buildCritBehavior();
+        // return critBehavior;
+        let critBehavior = fetchSetting("crit-behavior"); // Fetch the critical behavior setting
+
+        // Adjust for critical hit dice types
+        if (selectedType === rollTypes.critical) {
+            if (critBehavior === "double-die-count") {
+                diceCounts = doubleDieCountsForGroups(group); // TODO: This doesn't work. Hasn't been implemented yet.
+            }
+            selectedType = rollTypes.normal; // Reset to normal type after handling critical dice
         } else {
-            console.error(`Could not find mod counter for ${groupId}`);
+            critBehavior = "none";
         }
 
-        updatedDiceGroupsData.push(groupDiceCounts);
-    });
-
-    diceGroupsData = updatedDiceGroupsData; // Update the diceGroupsData with the new data
-
-    // TODO: CONSIDER MOVING THIS TO A SEPARATE FUNCTION
-    // buildCritBehavior();
-    // return critBehavior;
-    let critBehavior = fetchSetting("crit-behavior"); // Fetch the critical behavior setting
-
-    // Adjust for critical hit dice types
-    if (selectedType === rollTypes.critical) {
-        if (critBehavior === "double-die-count") {
-            diceCounts = doubleDieCountsForGroups(group); // TODO: This doesn't work. Hasn't been implemented yet.
-        }
-        selectedType = rollTypes.normal; // Reset to normal type after handling critical dice
-    } else {
-        critBehavior = "none";
+        putDiceToRollIntoDiceTray(rollNameParam, selectedType, critBehavior);
     }
 
-    putDiceToRollIntoDiceTray(rollNameParam, selectedType, critBehavior);
-}
+    function putDiceToRollIntoDiceTray(
+        rollNameParam,
+        selectedType,
+        critBehavior
+    ) {
+        try {
+            let rollName = buildRollName(
+                rollNameParam,
+                selectedType,
+                critBehavior
+            );
+            let baseDiceDescriptors = constructDiceRollDescriptors(rollName);
+            let trayConfiguration = buildDiceTrayConfiguration(
+                baseDiceDescriptors,
+                selectedType
+            );
 
-function putDiceToRollIntoDiceTray(rollNameParam, selectedType, critBehavior) {
-    try {
-        let rollName = buildRollName(rollNameParam, selectedType, critBehavior);
-        let baseDiceDescriptors = constructDiceRollDescriptors(rollName);
-        let trayConfiguration = buildDiceTrayConfiguration(
-            baseDiceDescriptors,
-            selectedType
-        );
-
-        TS.dice.putDiceInTray(trayConfiguration, true).then((rollId) => {
-            trackedRollIds[rollId] = {
-                type: selectedType,
-                critBehavior: critBehavior,
-            };
-        });
-    } catch (error) {
-        console.error("Error creating roll descriptors:", error);
-    }
-}
-
-/**
- * Constructs a dice tray configuration based on the base set of dice descriptors
- * and the roll type.
- *
- * This function generates a configuration for a dice tray, which is used to simulate
- * rolling dice in TaleSpire's digital environment. It takes a base set of dice
- * descriptors (each descriptor detailing the type and number of dice) and replicates
- * this set according to the number of rolls dictated by the roll type. The roll type
- * determines how many times the dice should be rolled (e.g., once for a normal roll,
- * twice for advantage/disadvantage, etc.), and this function adjusts the dice tray
- * configuration accordingly.
- *
- * The resulting array of dice descriptors represents the total set of dice to be rolled
- * in the simulation, accounting for the roll type's requirements.
- *
- * @param {Array<Object>} baseSetOfDiceDescriptors - An array of objects, each describing
- *                                                   a set of dice to be rolled (type and
- *                                                   count).
- * @param {string} rollType - A string indicating the type of roll (e.g., 'normal',
- *                            'advantage', 'disadvantage'), which affects the number
- *                            of dice rolled.
- *
- * @returns {Array<Object>} An array of dice descriptors adjusted for the roll type, representing the configuration of the dice tray.
- */
-function buildDiceTrayConfiguration(baseSetOfDiceDescriptors, rollType) {
-    let rollCount = getRollCount(rollType);
-    let diceDescriptors = [];
-
-    for (let i = 0; i < rollCount; i++) {
-        diceDescriptors.push(...baseSetOfDiceDescriptors);
-    }
-
-    return diceDescriptors;
-}
-
-/**
- * Determines the number of dice rolls to perform based on the roll type.
- *
- * This function takes a roll type as input and returns the number of times a
- * dice should be rolled according to the specified roll type. The roll types
- * include 'advantage', 'disadvantage', and 'bestofThree'.
- *
- * - For 'advantage' and 'disadvantage', the function returns 2, indicating that
- *   two dice should be rolled.
- * - For 'bestofThree', it returns 3, indicating that three dice should be rolled.
- * - For any other roll type, it defaults to returning 1, indicating a single dice
- *   roll.
- *
- * @param {string} rollType - The type of roll being performed, which determines
- *                            the number of dice rolls.
- *
- * @returns {number} The number of times to roll the dice based on the specified roll type.
- */
-function getRollCount(rollType) {
-    switch (rollType) {
-        case rollTypes.advantage:
-        case rollTypes.disadvantage:
-            return 2;
-
-        case rollTypes.bestofThree:
-            return 3;
-
-        default:
-            return 1;
-    }
-}
-
-// SORTED IN THEIR ORDER OF EXECUTION ABOVE
-// ----------------------------
-// function buildDiceGroupsData() {
-// }
-
-// function buildCritBehavior() {
-// }
-
-/**
- * Constructs a descriptive name for a roll based on provided parameters and
- * optional document elements.
- *
- * @param {string} rollNameParam - The base name for the roll. If not provided,
- *                                 attempts to use the value from the document's
- *                                 "roll-name" element.
- * @param {string} rollTypeParam - The type of the roll (e.g., "normal", "advantage",
- *                                 "disadvantage", "crit-dice").
- * @param {string} critBehaviorParam - The behavior of critical hits (e.g.,
- *                                     "double-die-count", "double-die-result",
- *                                     "double-total", "max-die", "max-plus").
- *
- * @returns {string} The constructed roll name, combining the base name, roll type,
- *                   and critical hit behavior.
- */
-function buildRollName(rollNameParam, rollTypeParam, critBehaviorParam) {
-    let rollName =
-        rollNameParam ||
-        document.getElementById("roll-name").value ||
-        "Unnamed Roll";
-
-    if (rollTypeParam !== "normal" && rollTypeParam !== "crit-dice") {
-        rollName += "\n" + formatRollTypeName(rollTypeParam);
-    }
-
-    if (rollTypeParam === "crit-dice") {
-        if (critBehaviorParam === "double-die-count") {
-            rollName += "\nCrit! Double the Dice";
-        }
-        if (critBehaviorParam === "double-die-result") {
-            rollName += "\nCrit! Double the Die Results";
-        }
-        if (critBehaviorParam === "double-total") {
-            rollName += "\nCrit! Double the Total";
-        }
-        if (critBehaviorParam === "max-die") {
-            rollName += "\nCrit! Maximize the Die";
-        }
-        if (critBehaviorParam === "max-plus") {
-            rollName += "\nCrit! Maximize Die plus Die Result";
+            TS.dice.putDiceInTray(trayConfiguration, true).then((rollId) => {
+                trackedRollIds[rollId] = {
+                    type: selectedType,
+                    critBehavior: critBehavior,
+                };
+            });
+        } catch (error) {
+            console.error("Error creating roll descriptors:", error);
         }
     }
 
-    return rollName;
-}
+    /**
+     * Constructs a dice tray configuration based on the base set of dice descriptors
+     * and the roll type.
+     *
+     * This function generates a configuration for a dice tray, which is used to simulate
+     * rolling dice in TaleSpire's digital environment. It takes a base set of dice
+     * descriptors (each descriptor detailing the type and number of dice) and replicates
+     * this set according to the number of rolls dictated by the roll type. The roll type
+     * determines how many times the dice should be rolled (e.g., once for a normal roll,
+     * twice for advantage/disadvantage, etc.), and this function adjusts the dice tray
+     * configuration accordingly.
+     *
+     * The resulting array of dice descriptors represents the total set of dice to be rolled
+     * in the simulation, accounting for the roll type's requirements.
+     *
+     * @param {Array<Object>} baseSetOfDiceDescriptors - An array of objects, each describing
+     *                                                   a set of dice to be rolled (type and
+     *                                                   count).
+     * @param {string} rollType - A string indicating the type of roll (e.g., 'normal',
+     *                            'advantage', 'disadvantage'), which affects the number
+     *                            of dice rolled.
+     *
+     * @returns {Array<Object>} An array of dice descriptors adjusted for the roll type, representing the configuration of the dice tray.
+     */
+    function buildDiceTrayConfiguration(baseSetOfDiceDescriptors, rollType) {
+        let rollCount = getRollCount(rollType);
+        let diceDescriptors = [];
 
-/**
- * Formats the internal roll type name into a human-readable string.
- *
- * @param {string} rollType - The internal identifier for the roll type.
- *
- * @returns {string} The human-readable string representation of the roll type.
- */
-function formatRollTypeName(rollType) {
-    const rollTypeMappings = {
-        normal: "Normal",
-        advantage: "Advantage",
-        disadvantage: "Disadvantage",
-        "best-of-three": "Best of Three",
-    };
+        for (let i = 0; i < rollCount; i++) {
+            diceDescriptors.push(...baseSetOfDiceDescriptors);
+        }
 
-    return rollTypeMappings[rollType] || rollType;
-}
+        return diceDescriptors;
+    }
 
-// function buildDiceRollObject() {
-// }
+    /**
+     * Determines the number of dice rolls to perform based on the roll type.
+     *
+     * This function takes a roll type as input and returns the number of times a
+     * dice should be rolled according to the specified roll type. The roll types
+     * include 'advantage', 'disadvantage', and 'bestofThree'.
+     *
+     * - For 'advantage' and 'disadvantage', the function returns 2, indicating that
+     *   two dice should be rolled.
+     * - For 'bestofThree', it returns 3, indicating that three dice should be rolled.
+     * - For any other roll type, it defaults to returning 1, indicating a single dice
+     *   roll.
+     *
+     * @param {string} rollType - The type of roll being performed, which determines
+     *                            the number of dice rolls.
+     *
+     * @returns {number} The number of times to roll the dice based on the specified roll type.
+     */
+    function getRollCount(rollType) {
+        switch (rollType) {
+            case rollTypes.advantage:
+            case rollTypes.disadvantage:
+                return 2;
 
-/**
- * Constructs an array of dice roll descriptors based on the provided roll name
- * and dice groups data.
- *
- * This function iterates over each group of dice counts provided in the global
- * `diceGroupsData` array. For each group, it constructs a string representation
- * of the dice rolls, including the count and type of each die, and any modifiers.
- * These strings are then used to create objects that pair the provided roll name
- * with the constructed roll string.
- *
- * The function is designed to support the
- * [Talespire URL scheme](https://feedback.talespire.com/kb/article/talespire-url-scheme)
- * for dice rolls, allowing these descriptors to be used for generating URLs that
- * trigger specific dice rolls within the Talespire game.
- *
- * Example of a dice roll object in the returned array:
- * ```
- * {
- *     name: 'TEST',
- *     roll: '+1d4+1d6+5'
- * }
- * ```
- *
- * @param {string} rollName - The name to be associated with each dice roll descriptor.
- *
- * @returns {Array<Object>} An array of objects, each containing a `name` and a `roll`
- *                          string that describes the dice roll.
- */
-function constructDiceRollDescriptors(rollName) {
-    // Create an empty array to store the dice roll objects
-    let diceRollObjects = [];
+            case rollTypes.bestofThree:
+                return 3;
 
-    // Iterate over each dice group in the diceGroupsData array
-    for (const groupDiceCounts of diceGroupsData) {
-        let groupRollString = "";
-        let formattedDiceGroup = [];
+            default:
+                return 1;
+        }
+    }
 
-        for (const [die, count] of Object.entries(groupDiceCounts)) {
-            if (die !== "mod" && count > 0) {
-                formattedDiceGroup.push(`${count}${die}`);
-                groupRollString = groupRollString + `+${count}${die}`;
+    // SORTED IN THEIR ORDER OF EXECUTION ABOVE
+    // ----------------------------
+    // function buildDiceGroupsData() {
+    // }
+
+    // function buildCritBehavior() {
+    // }
+
+    /**
+     * Constructs a descriptive name for a roll based on provided parameters and
+     * optional document elements.
+     *
+     * @param {string} rollNameParam - The base name for the roll. If not provided,
+     *                                 attempts to use the value from the document's
+     *                                 "roll-name" element.
+     * @param {string} rollTypeParam - The type of the roll (e.g., "normal", "advantage",
+     *                                 "disadvantage", "crit-dice").
+     * @param {string} critBehaviorParam - The behavior of critical hits (e.g.,
+     *                                     "double-die-count", "double-die-result",
+     *                                     "double-total", "max-die", "max-plus").
+     *
+     * @returns {string} The constructed roll name, combining the base name, roll type,
+     *                   and critical hit behavior.
+     */
+    function buildRollName(rollNameParam, rollTypeParam, critBehaviorParam) {
+        let rollName =
+            rollNameParam ||
+            document.getElementById("roll-name").value ||
+            "Unnamed Roll";
+
+        if (rollTypeParam !== "normal" && rollTypeParam !== "crit-dice") {
+            rollName += "\n" + formatRollTypeName(rollTypeParam);
+        }
+
+        if (rollTypeParam === "crit-dice") {
+            if (critBehaviorParam === "double-die-count") {
+                rollName += "\nCrit! Double the Dice";
+            }
+            if (critBehaviorParam === "double-die-result") {
+                rollName += "\nCrit! Double the Die Results";
+            }
+            if (critBehaviorParam === "double-total") {
+                rollName += "\nCrit! Double the Total";
+            }
+            if (critBehaviorParam === "max-die") {
+                rollName += "\nCrit! Maximize the Die";
+            }
+            if (critBehaviorParam === "max-plus") {
+                rollName += "\nCrit! Maximize Die plus Die Result";
             }
         }
 
-        let modValue = parseInt(groupDiceCounts.mod, 10);
+        return rollName;
+    }
 
-        if (modValue !== 0) {
-            let modPart = modValue > 0 ? `+${modValue}` : `${modValue}`;
-            groupRollString = groupRollString + modPart;
+    /**
+     * Formats the internal roll type name into a human-readable string.
+     *
+     * @param {string} rollType - The internal identifier for the roll type.
+     *
+     * @returns {string} The human-readable string representation of the roll type.
+     */
+    function formatRollTypeName(rollType) {
+        const rollTypeMappings = {
+            normal: "Normal",
+            advantage: "Advantage",
+            disadvantage: "Disadvantage",
+            "best-of-three": "Best of Three",
+        };
+
+        return rollTypeMappings[rollType] || rollType;
+    }
+
+    // function buildDiceRollObject() {
+    // }
+
+    /**
+     * Constructs an array of dice roll descriptors based on the provided roll name
+     * and dice groups data.
+     *
+     * This function iterates over each group of dice counts provided in the global
+     * `diceGroupsData` array. For each group, it constructs a string representation
+     * of the dice rolls, including the count and type of each die, and any modifiers.
+     * These strings are then used to create objects that pair the provided roll name
+     * with the constructed roll string.
+     *
+     * The function is designed to support the
+     * [Talespire URL scheme](https://feedback.talespire.com/kb/article/talespire-url-scheme)
+     * for dice rolls, allowing these descriptors to be used for generating URLs that
+     * trigger specific dice rolls within the Talespire game.
+     *
+     * Example of a dice roll object in the returned array:
+     * ```
+     * {
+     *     name: 'TEST',
+     *     roll: '+1d4+1d6+5'
+     * }
+     * ```
+     *
+     * @param {string} rollName - The name to be associated with each dice roll descriptor.
+     *
+     * @returns {Array<Object>} An array of objects, each containing a `name` and a `roll`
+     *                          string that describes the dice roll.
+     */
+    function constructDiceRollDescriptors(rollName) {
+        // Create an empty array to store the dice roll objects
+        let diceRollObjects = [];
+
+        // Iterate over each dice group in the diceGroupsData array
+        for (const groupDiceCounts of diceGroupsData) {
+            let groupRollString = "";
+            let formattedDiceGroup = [];
+
+            for (const [die, count] of Object.entries(groupDiceCounts)) {
+                if (die !== "mod" && count > 0) {
+                    formattedDiceGroup.push(`${count}${die}`);
+                    groupRollString = groupRollString + `+${count}${die}`;
+                }
+            }
+
+            let modValue = parseInt(groupDiceCounts.mod, 10);
+
+            if (modValue !== 0) {
+                let modPart = modValue > 0 ? `+${modValue}` : `${modValue}`;
+                groupRollString = groupRollString + modPart;
+            }
+
+            let rollObject = { name: rollName, roll: groupRollString };
+            diceRollObjects.push(rollObject);
         }
 
-        let rollObject = { name: rollName, roll: groupRollString };
-        diceRollObjects.push(rollObject);
+        return diceRollObjects;
     }
 
-    return diceRollObjects;
-}
+    /**
+     * Handles the processing of roll events, including roll results and roll removals.
+     *
+     * [onRollResults handler](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#subscriptions/dice/onrollresults)
+     *
+     * @param {Object} rollEvent - An object representing a roll event, containing a
+     *                             payload with the roll ID and other relevant information.
+     *
+     * @returns {Promise<void>} A promise that resolves once the roll event has been processed.
+     */
+    async function handleRollResult(rollEvent) {
+        if (trackedRollIds[rollEvent.payload.rollId] == undefined) {
+            console.error(
+                `Tracked Roll for ID \"${rollEvent.payload.rollId}\" not found.`
+            );
+            return;
+        }
 
-/**
- * Handles the processing of roll events, including roll results and roll removals.
- *
- * [onRollResults handler](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#subscriptions/dice/onrollresults)
- *
- * @param {Object} rollEvent - An object representing a roll event, containing a
- *                             payload with the roll ID and other relevant information.
- *
- * @returns {Promise<void>} A promise that resolves once the roll event has been processed.
- */
-async function handleRollResult(rollEvent) {
-    if (trackedRollIds[rollEvent.payload.rollId] == undefined) {
-        console.error(
-            `Tracked Roll for ID \"${rollEvent.payload.rollId}\" not found.`
-        );
-        return;
+        if (!isValidRollEvent(rollEvent.kind)) {
+            console.error(`Invalid roll event: ${rollEvent.kind}`);
+            return;
+        }
+
+        if (rollEvent.kind == rollEvents.rollRemoved) {
+            handleRollRemovedEvent(rollEvent);
+        } else if (rollEvent.kind == rollEvents.rollResults) {
+            await handleRollResultsEvent(rollEvent);
+        }
     }
 
-    if (!isValidRollEvent(rollEvent.kind)) {
-        console.error(`Invalid roll event: ${rollEvent.kind}`);
-        return;
+    /**
+     * Checks if the given event name corresponds to a valid TaleSpire roll event.
+     *
+     * @param {string} eventName - The name of the event to check for validity.
+     *
+     * @returns {boolean} True if the event name is valid (matches 'rollResults'
+     *                    or 'rollRemoved'), otherwise false.
+     */
+    function isValidRollEvent(eventName) {
+        if (
+            eventName == rollEvents.rollResults ||
+            eventName == rollEvents.rollRemoved
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
-    if (rollEvent.kind == rollEvents.rollRemoved) {
-        handleRollRemovedEvent(rollEvent);
-    } else if (rollEvent.kind == rollEvents.rollResults) {
-        await handleRollResultsEvent(rollEvent);
-    }
-}
-
-/**
- * Checks if the given event name corresponds to a valid TaleSpire roll event.
- *
- * @param {string} eventName - The name of the event to check for validity.
- *
- * @returns {boolean} True if the event name is valid (matches 'rollResults'
- *                    or 'rollRemoved'), otherwise false.
- */
-function isValidRollEvent(eventName) {
-    if (
-        eventName == rollEvents.rollResults ||
-        eventName == rollEvents.rollRemoved
-    ) {
-        return true;
+    /**
+     * Processes a roll removed event and removes a roll from the tracked
+     * rolls collection.
+     *
+     * [rollRemoved event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollremoved)
+     *
+     * @param {Object} rollEvent - An object representing a roll removal
+     *                             event, containing the payload with the
+     *                             roll ID to be removed.
+     */
+    function handleRollRemovedEvent(rollEvent) {
+        delete trackedRollIds[rollEvent.payload.rollId];
     }
 
-    return false;
-}
+    /**
+     * Processes a roll results event and applies specific roll handling based on
+     * the roll type and critical hit behavior.
+     *
+     * [rollResults event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollresults)
+     *
+     * @param {Object} rollEvent - An object representing a roll event, containing the
+     *                             payload with roll details.
+     *
+     * @returns {Promise<void>} A promise that resolves when the roll results have been
+     *                          processed and displayed.
+     */
+    async function handleRollResultsEvent(rollEvent) {
+        let roll = rollEvent.payload;
+        let resultGroup = {};
 
-/**
- * Processes a roll removed event and removes a roll from the tracked
- * rolls collection.
- *
- * [rollRemoved event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollremoved)
- *
- * @param {Object} rollEvent - An object representing a roll removal
- *                             event, containing the payload with the
- *                             roll ID to be removed.
- */
-function handleRollRemovedEvent(rollEvent) {
-    delete trackedRollIds[rollEvent.payload.rollId];
-}
+        if (roll.resultsGroups != undefined) {
+            let rollInfo = trackedRollIds[roll.rollId];
 
-/**
- * Processes a roll results event and applies specific roll handling based on
- * the roll type and critical hit behavior.
- *
- * [rollResults event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollresults)
- *
- * @param {Object} rollEvent - An object representing a roll event, containing the
- *                             payload with roll details.
- *
- * @returns {Promise<void>} A promise that resolves when the roll results have been
- *                          processed and displayed.
- */
-async function handleRollResultsEvent(rollEvent) {
-    let roll = rollEvent.payload;
-    let resultGroup = {};
+            resultGroup = await getReportableRollResultsGroup(
+                roll,
+                rollInfo.type
+            );
 
-    if (roll.resultsGroups != undefined) {
-        let rollInfo = trackedRollIds[roll.rollId];
+            resultGroup = applyCritBehaviorToRollResultsGroup(
+                resultGroup,
+                rollInfo.critBehavior
+            );
+        }
 
-        resultGroup = await getReportableRollResultsGroup(roll, rollInfo.type);
-
-        resultGroup = applyCritBehaviorToRollResultsGroup(
-            resultGroup,
-            rollInfo.critBehavior
-        );
+        displayResult(resultGroup, roll.rollId);
     }
 
-    displayResult(resultGroup, roll.rollId);
-}
+    /**
+     * Retrieves the reportable roll results group based on the roll and roll type.
+     *
+     * This function is designed to handle the complexity of different roll types in games,
+     * ensuring that the correct results are reported based on the Symbiotes's rules for
+     * advantage, disadvantage, and other roll types.
+     *
+     * @param {Object} roll - The roll object containing the dice roll information.
+     * @param {string} rollType - A string representing the type of roll (e.g., 'advantage',
+     *                            'disadvantage', 'bestofThree').
+     *
+     * @returns {Promise<Object>} A promise that resolves with the reportable roll
+     *                            results group.
+     */
+    async function getReportableRollResultsGroup(roll, rollType) {
+        switch (rollType) {
+            case rollTypes.advantage:
+                return await handleAdvantageRoll(roll);
 
-/**
- * Retrieves the reportable roll results group based on the roll and roll type.
- *
- * This function is designed to handle the complexity of different roll types in games,
- * ensuring that the correct results are reported based on the Symbiotes's rules for
- * advantage, disadvantage, and other roll types.
- *
- * @param {Object} roll - The roll object containing the dice roll information.
- * @param {string} rollType - A string representing the type of roll (e.g., 'advantage',
- *                            'disadvantage', 'bestofThree').
- *
- * @returns {Promise<Object>} A promise that resolves with the reportable roll
- *                            results group.
- */
-async function getReportableRollResultsGroup(roll, rollType) {
-    switch (rollType) {
-        case rollTypes.advantage:
-            return await handleAdvantageRoll(roll);
+            case rollTypes.disadvantage:
+                return await handleDisadvantageRoll(roll);
 
-        case rollTypes.disadvantage:
-            return await handleDisadvantageRoll(roll);
+            case rollTypes.bestofThree:
+                return await handleBestOfThreeRoll(roll);
 
-        case rollTypes.bestofThree:
-            return await handleBestOfThreeRoll(roll);
+            default:
+                return roll.resultsGroups;
+        }
+    }
 
-        default:
+    /**
+     * Handle the calculation of roll results under the advantage condition.
+     *
+     * @param {Object} roll             - An object representing a roll, which contains an array of
+     *                                    results groups.
+     *
+     * @returns {Promise<Array>} A promise that resolves to an array representing the
+     *                           set of roll results with the highest sum.
+     */
+    async function handleAdvantageRoll(roll) {
+        return await handleAdvantageDisadvantageRoll(roll, true);
+    }
+
+    /**
+     * Handle the calculation of roll results under the disadvantage condition.
+     *
+     * @param {Object} roll             - An object representing a roll, which contains an array of
+     *                                    results groups.
+     *
+     * @returns {Promise<Array>} A promise that resolves to an array representing the
+     *                           set of roll results with the lowest sum.
+     */
+    async function handleDisadvantageRoll(roll) {
+        return await handleAdvantageDisadvantageRoll(roll, false);
+    }
+
+    /**
+     * Handles the calculation of roll results under advantage or disadvantage conditions.
+     *
+     * This function takes a roll object and a boolean indicating whether the roll is
+     * under advantage or disadvantage conditions. It divides the roll's results into
+     * two equal sets. If the number of results groups is less than 2 or not even, it
+     * returns the original results groups. It then calculates the sum of each set.
+     * Under advantage conditions, it returns the set with the higher sum; under disadvantage
+     * conditions, it returns the set with the lower sum.
+     *
+     * @param {Object} roll             - An object representing a roll, which contains an array of
+     *                                    results groups.
+     * @param {boolean} isAdvantage     - A boolean indicating if the roll is under advantage (true)
+     *                                    or disadvantage (false) conditions.
+     *
+     * @returns {Promise<Array>} A promise that resolves to an array representing the
+     *                           set of roll results with either the highest sum (advantage)
+     *                           or the lowest sum (disadvantage).
+     */
+    async function handleAdvantageDisadvantageRoll(roll, isAdvantage) {
+        if (
+            roll.resultsGroups.length < 2 ||
+            roll.resultsGroups.length % 2 != 0
+        ) {
             return roll.resultsGroups;
-    }
-}
+        }
 
-/**
- * Handle the calculation of roll results under the advantage condition.
- *
- * @param {Object} roll             - An object representing a roll, which contains an array of
- *                                    results groups.
- *
- * @returns {Promise<Array>} A promise that resolves to an array representing the
- *                           set of roll results with the highest sum.
- */
-async function handleAdvantageRoll(roll) {
-    return await handleAdvantageDisadvantageRoll(roll, true);
-}
+        let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 2;
 
-/**
- * Handle the calculation of roll results under the disadvantage condition.
- *
- * @param {Object} roll             - An object representing a roll, which contains an array of
- *                                    results groups.
- *
- * @returns {Promise<Array>} A promise that resolves to an array representing the
- *                           set of roll results with the lowest sum.
- */
-async function handleDisadvantageRoll(roll) {
-    return await handleAdvantageDisadvantageRoll(roll, false);
-}
-
-/**
- * Handles the calculation of roll results under advantage or disadvantage conditions.
- *
- * This function takes a roll object and a boolean indicating whether the roll is
- * under advantage or disadvantage conditions. It divides the roll's results into
- * two equal sets. If the number of results groups is less than 2 or not even, it
- * returns the original results groups. It then calculates the sum of each set.
- * Under advantage conditions, it returns the set with the higher sum; under disadvantage
- * conditions, it returns the set with the lower sum.
- *
- * @param {Object} roll             - An object representing a roll, which contains an array of
- *                                    results groups.
- * @param {boolean} isAdvantage     - A boolean indicating if the roll is under advantage (true)
- *                                    or disadvantage (false) conditions.
- *
- * @returns {Promise<Array>} A promise that resolves to an array representing the
- *                           set of roll results with either the highest sum (advantage)
- *                           or the lowest sum (disadvantage).
- */
-async function handleAdvantageDisadvantageRoll(roll, isAdvantage) {
-    if (roll.resultsGroups.length < 2 || roll.resultsGroups.length % 2 != 0) {
-        return roll.resultsGroups;
-    }
-
-    let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 2;
-
-    let firstSetOfGroups = roll.resultsGroups.slice(
-        0,
-        startingIndexOfSecondSetOfGroups
-    );
-
-    let secondSetOfGroups = roll.resultsGroups.slice(
-        startingIndexOfSecondSetOfGroups
-    );
-
-    let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
-    let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
-
-    let setWithHighestSum = [];
-    let setWithLowestSum = [];
-
-    if (sumOfFirstSet >= sumOfSecondSet) {
-        setWithHighestSum = firstSetOfGroups;
-        setWithLowestSum = secondSetOfGroups;
-    } else {
-        setWithHighestSum = secondSetOfGroups;
-        setWithLowestSum = firstSetOfGroups;
-    }
-
-    if (isAdvantage == true) {
-        return setWithHighestSum;
-    }
-
-    return setWithLowestSum;
-}
-
-/**
- * Processes a roll containing multiple groups of roll results and selects the
- * best set of results based on their sum.
- *
- * This function divides the roll's results into three equal sets and calculates
- * the sum of each set. It then compares these sums to determine which set has
- * the highest total sum. If the number of results groups is not a multiple of
- * three or is less than three, the function returns the original roll results
- * groups without modification.
- *
- * @param {Object} roll - An object representing a roll, which contains an array
- *                        of results groups.
- *
- * @returns {Promise<Array>} A promise that resolves to an array representing the
- *                           set of roll results with the highest sum. If the input
- *                           does not meet the required conditions (e.g., not
- *                           divisible by three, less than three groups), it returns
- *                           the original array of roll results groups.
- */
-async function handleBestOfThreeRoll(roll) {
-    if (roll.resultsGroups.length < 3 || roll.resultsGroups.length % 3 != 0) {
-        return roll.resultsGroups;
-    }
-
-    let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 3;
-    let startingIndexOfThirdSetOfGroups = startingIndexOfSecondSetOfGroups * 2;
-
-    let firstSetOfGroups = roll.resultsGroups.slice(
-        0,
-        startingIndexOfSecondSetOfGroups
-    );
-
-    let secondSetOfGroups = roll.resultsGroups.slice(
-        startingIndexOfSecondSetOfGroups,
-        startingIndexOfThirdSetOfGroups
-    );
-
-    let thirdSetOfGroups = roll.resultsGroups.slice(
-        startingIndexOfThirdSetOfGroups
-    );
-
-    let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
-    let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
-    let sumOfThirdSet = await getSumOfRollResultsGroups(thirdSetOfGroups);
-
-    if (sumOfFirstSet >= sumOfSecondSet && sumOfFirstSet >= sumOfThirdSet) {
-        return firstSetOfGroups;
-    } else if (
-        sumOfSecondSet >= sumOfFirstSet &&
-        sumOfSecondSet >= sumOfThirdSet
-    ) {
-        return secondSetOfGroups;
-    } else {
-        return thirdSetOfGroups;
-    }
-}
-
-/**
- * Calculates the total sum of multiple groups of dice roll results.
- *
- * This function takes an array of roll results groups, where each group
- * represents a collection of dice roll results. It asynchronously evaluates
- * the sum of each group using a provided evaluation function
- * (`TS.dice.evaluateDiceResultsGroup`), then calculates and returns the total
- * sum of these group sums.
- *
- * @param {Array} rollResultsGroups - An array of roll results groups, where
- *                                    each group is a collection that can be
- *                                    evaluated into a sum.
- *
- * @returns {Promise<number>} A promise that resolves to the total sum of the
- *                            evaluated sums of each group in `rollResultsGroups`.
- */
-async function getSumOfRollResultsGroups(rollResultsGroups) {
-    let sum = 0;
-
-    for (let resultsGroup of rollResultsGroups) {
-        sum += await TS.dice.evaluateDiceResultsGroup(resultsGroup);
-    }
-
-    return sum;
-}
-
-/**
- * Applies critical hit behavior to a group of roll results.
- *
- * This function modifies the given roll results group based on the specified
- * critical hit behavior. The critical hit behaviors include:
- * - "double-total": Doubles both the dice results and any modifiers in the results group.
- * - "double-die-result": Doubles the dice results in the results group.
- * - "max-die": Maximizes the dice results in the results group, setting each die to its maximum possible value.
- * - "max-plus": Adds the maximum possible value of each die type to the results group.
- *
- * The function returns a new results group object with the applied modifications
- *
- * @param {Object} resultGroup - The original group of roll results to be modified.
- * @param {string} critBehavior - A string indicating the type of critical hit behavior
- *                                to apply to the roll results.
- *
- * @returns {Object} The modified group of roll results with the critical hit behavior
- *                   applied.
- */
-function applyCritBehaviorToRollResultsGroup(resultGroup, critBehavior) {
-    let updatedResultsGroup = resultGroup;
-
-    if (critBehavior === "double-total") {
-        updatedResultsGroup = doubleDiceResults(updatedResultsGroup);
-        updatedResultsGroup = doubleModifier(updatedResultsGroup);
-    } else if (critBehavior === "double-die-result") {
-        updatedResultsGroup = doubleDiceResults(updatedResultsGroup);
-    } else if (critBehavior === "max-die") {
-        updatedResultsGroup = maximizeDiceResults(updatedResultsGroup);
-    } else if (critBehavior === "max-plus") {
-        updatedResultsGroup = addMaxDieForEachKind(updatedResultsGroup);
-    }
-
-    return updatedResultsGroup;
-}
-
-/**
- * Asynchronously sends a dice roll result to the TaleSpire game interface.
- *
- * This function is responsible for communicating the result of a dice roll,
- * encapsulated within `resultGroup`, to the Talespire game via the `TS.dice.sendDiceResult`
- * method. It uses the `rollId` to associate the result with a specific roll.
- * If the operation fails, an error message is logged to the console detailing
- * the failure.
- *
- * @param {Object} resultGroup - An object containing the dice roll results to be sent.
- * @param {string} rollId - A unique identifier for the roll, used to track the result
- *                          within the Talespire game.
- *
- * @returns {Promise<void>} A promise that resolves when the dice result has been
- *                          successfully sent or logs an error upon failure.
- */
-function displayResult(resultGroup, rollId) {
-    TS.dice
-        .sendDiceResult(resultGroup, rollId)
-        .catch((response) =>
-            console.error("error in sending dice result", response)
+        let firstSetOfGroups = roll.resultsGroups.slice(
+            0,
+            startingIndexOfSecondSetOfGroups
         );
-}
+
+        let secondSetOfGroups = roll.resultsGroups.slice(
+            startingIndexOfSecondSetOfGroups
+        );
+
+        let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
+        let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
+
+        let setWithHighestSum = [];
+        let setWithLowestSum = [];
+
+        if (sumOfFirstSet >= sumOfSecondSet) {
+            setWithHighestSum = firstSetOfGroups;
+            setWithLowestSum = secondSetOfGroups;
+        } else {
+            setWithHighestSum = secondSetOfGroups;
+            setWithLowestSum = firstSetOfGroups;
+        }
+
+        if (isAdvantage == true) {
+            return setWithHighestSum;
+        }
+
+        return setWithLowestSum;
+    }
+
+    /**
+     * Processes a roll containing multiple groups of roll results and selects the
+     * best set of results based on their sum.
+     *
+     * This function divides the roll's results into three equal sets and calculates
+     * the sum of each set. It then compares these sums to determine which set has
+     * the highest total sum. If the number of results groups is not a multiple of
+     * three or is less than three, the function returns the original roll results
+     * groups without modification.
+     *
+     * @param {Object} roll - An object representing a roll, which contains an array
+     *                        of results groups.
+     *
+     * @returns {Promise<Array>} A promise that resolves to an array representing the
+     *                           set of roll results with the highest sum. If the input
+     *                           does not meet the required conditions (e.g., not
+     *                           divisible by three, less than three groups), it returns
+     *                           the original array of roll results groups.
+     */
+    async function handleBestOfThreeRoll(roll) {
+        if (
+            roll.resultsGroups.length < 3 ||
+            roll.resultsGroups.length % 3 != 0
+        ) {
+            return roll.resultsGroups;
+        }
+
+        let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 3;
+        let startingIndexOfThirdSetOfGroups =
+            startingIndexOfSecondSetOfGroups * 2;
+
+        let firstSetOfGroups = roll.resultsGroups.slice(
+            0,
+            startingIndexOfSecondSetOfGroups
+        );
+
+        let secondSetOfGroups = roll.resultsGroups.slice(
+            startingIndexOfSecondSetOfGroups,
+            startingIndexOfThirdSetOfGroups
+        );
+
+        let thirdSetOfGroups = roll.resultsGroups.slice(
+            startingIndexOfThirdSetOfGroups
+        );
+
+        let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
+        let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
+        let sumOfThirdSet = await getSumOfRollResultsGroups(thirdSetOfGroups);
+
+        if (sumOfFirstSet >= sumOfSecondSet && sumOfFirstSet >= sumOfThirdSet) {
+            return firstSetOfGroups;
+        } else if (
+            sumOfSecondSet >= sumOfFirstSet &&
+            sumOfSecondSet >= sumOfThirdSet
+        ) {
+            return secondSetOfGroups;
+        } else {
+            return thirdSetOfGroups;
+        }
+    }
+
+    /**
+     * Calculates the total sum of multiple groups of dice roll results.
+     *
+     * This function takes an array of roll results groups, where each group
+     * represents a collection of dice roll results. It asynchronously evaluates
+     * the sum of each group using a provided evaluation function
+     * (`TS.dice.evaluateDiceResultsGroup`), then calculates and returns the total
+     * sum of these group sums.
+     *
+     * @param {Array} rollResultsGroups - An array of roll results groups, where
+     *                                    each group is a collection that can be
+     *                                    evaluated into a sum.
+     *
+     * @returns {Promise<number>} A promise that resolves to the total sum of the
+     *                            evaluated sums of each group in `rollResultsGroups`.
+     */
+    async function getSumOfRollResultsGroups(rollResultsGroups) {
+        let sum = 0;
+
+        for (let resultsGroup of rollResultsGroups) {
+            sum += await TS.dice.evaluateDiceResultsGroup(resultsGroup);
+        }
+
+        return sum;
+    }
+
+    /**
+     * Applies critical hit behavior to a group of roll results.
+     *
+     * This function modifies the given roll results group based on the specified
+     * critical hit behavior. The critical hit behaviors include:
+     * - "double-total": Doubles both the dice results and any modifiers in the results group.
+     * - "double-die-result": Doubles the dice results in the results group.
+     * - "max-die": Maximizes the dice results in the results group, setting each die to its maximum possible value.
+     * - "max-plus": Adds the maximum possible value of each die type to the results group.
+     *
+     * The function returns a new results group object with the applied modifications
+     *
+     * @param {Object} resultGroup - The original group of roll results to be modified.
+     * @param {string} critBehavior - A string indicating the type of critical hit behavior
+     *                                to apply to the roll results.
+     *
+     * @returns {Object} The modified group of roll results with the critical hit behavior
+     *                   applied.
+     */
+    function applyCritBehaviorToRollResultsGroup(resultGroup, critBehavior) {
+        let updatedResultsGroup = resultGroup;
+
+        if (critBehavior === "double-total") {
+            updatedResultsGroup = doubleDiceResults(updatedResultsGroup);
+            updatedResultsGroup = doubleModifier(updatedResultsGroup);
+        } else if (critBehavior === "double-die-result") {
+            updatedResultsGroup = doubleDiceResults(updatedResultsGroup);
+        } else if (critBehavior === "max-die") {
+            updatedResultsGroup = maximizeDiceResults(updatedResultsGroup);
+        } else if (critBehavior === "max-plus") {
+            updatedResultsGroup = addMaxDieForEachKind(updatedResultsGroup);
+        }
+
+        return updatedResultsGroup;
+    }
+
+    /**
+     * Asynchronously sends a dice roll result to the TaleSpire game interface.
+     *
+     * This function is responsible for communicating the result of a dice roll,
+     * encapsulated within `resultGroup`, to the Talespire game via the `TS.dice.sendDiceResult`
+     * method. It uses the `rollId` to associate the result with a specific roll.
+     * If the operation fails, an error message is logged to the console detailing
+     * the failure.
+     *
+     * @param {Object} resultGroup - An object containing the dice roll results to be sent.
+     * @param {string} rollId - A unique identifier for the roll, used to track the result
+     *                          within the Talespire game.
+     *
+     * @returns {Promise<void>} A promise that resolves when the dice result has been
+     *                          successfully sent or logs an error upon failure.
+     */
+    function displayResult(resultGroup, rollId) {
+        TS.dice
+            .sendDiceResult(resultGroup, rollId)
+            .catch((response) =>
+                console.error("error in sending dice result", response)
+            );
+    }
+
+    // PUBLIC API //
+    return {
+        roll: roll,
+        handleRollResult: handleRollResult,
+    };
+})();

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -159,14 +159,6 @@ const rollsModule = (function () {
         }
     }
 
-    // SORTED IN THEIR ORDER OF EXECUTION ABOVE
-    // ----------------------------
-    // function buildDiceGroupsData() {
-    // }
-
-    // function buildCritBehavior() {
-    // }
-
     /**
      * Constructs a descriptive name for a roll based on provided parameters and
      * optional document elements.
@@ -231,9 +223,6 @@ const rollsModule = (function () {
 
         return rollTypeMappings[rollType] || rollType;
     }
-
-    // function buildDiceRollObject() {
-    // }
 
     /**
      * Constructs an array of dice roll descriptors based on the provided roll name

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -54,47 +54,16 @@ function roll(rollNameParam, rollTypeParam) {
     // buildDiceRollObject();
     // return diceRollObjects;
     // Construct the dice roll string from the dice groups
-    //let diceDescriptors = constructDiceRollString(rollName);
-
-    let baseDiceDescriptors = [
-        {
-            name: "test-4-groups",
-            roll: "+1d4+1d6",
-        },
-        {
-            name: "test-4-groups",
-            roll: "+1d4+1d6+100",
-        },
-    ];
-
-    // Simulate adding copies of the same groups for advantage/disadvantage
-    additionalDiceDescriptorCopies = [
-        // {
-        //     name: "test-4-groups",
-        //     roll: "+1d4+1d6",
-        // },
-        // {
-        //     name: "test-4-groups",
-        //     roll: "+1d4+1d6+100",
-        // },
-        // {
-        //     name: "test-4-groups",
-        //     roll: "+1d4+1d6",
-        // },
-        // {
-        //     name: "test-4-groups",
-        //     roll: "+1d4+1d6+100",
-        // },
-    ];
-
-    let diceDescriptors = [
-        ...baseDiceDescriptors,
-        ...additionalDiceDescriptorCopies,
-    ];
+    let baseDiceDescriptors = constructDiceRollString(rollName);
 
     try {
         // Create the roll object and descriptors then put the dice in the tray
         let rollCount = getRollCount(selectedType);
+        let diceDescriptors = [];
+
+        for (let i = 0; i < rollCount; i++) {
+            diceDescriptors.push(...baseDiceDescriptors);
+        }
 
         // ORIG: let trayConfiguration = Array(rollCount).fill(rollObject);
         let trayConfiguration = diceDescriptors; // Set the tray configuration to the dice roll objects
@@ -106,7 +75,6 @@ function roll(rollNameParam, rollTypeParam) {
             trackedRollIds[rollId] = {
                 type: selectedType,
                 critBehavior: critBehavior,
-                numberOfGroups: 2, //diceGroupsData.length,
             };
         });
     } catch (error) {

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -54,19 +54,13 @@ function roll(rollNameParam, rollTypeParam) {
     // buildDiceRollObject();
     // return diceRollObjects;
     // Construct the dice roll string from the dice groups
-    let baseDiceDescriptors = constructDiceRollString(rollName);
+    let baseDiceDescriptors = constructDiceRollDescriptors(rollName);
 
     try {
-        // Create the roll object and descriptors then put the dice in the tray
-        let rollCount = getRollCount(selectedType);
-        let diceDescriptors = [];
-
-        for (let i = 0; i < rollCount; i++) {
-            diceDescriptors.push(...baseDiceDescriptors);
-        }
-
-        // ORIG: let trayConfiguration = Array(rollCount).fill(rollObject);
-        let trayConfiguration = diceDescriptors; // Set the tray configuration to the dice roll objects
+        let trayConfiguration = buildDiceTrayConfiguration(
+            baseDiceDescriptors,
+            selectedType
+        );
 
         // Put dice in tray and handle the response
         // https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#calls/dice/putdiceintray
@@ -81,6 +75,17 @@ function roll(rollNameParam, rollTypeParam) {
         // Log any errors encountered during roll descriptor creation
         console.error("Error creating roll descriptors:", error);
     }
+}
+
+function buildDiceTrayConfiguration(baseSetOfDiceDescriptors, rollType) {
+    let rollCount = getRollCount(rollType);
+    let diceDescriptors = [];
+
+    for (let i = 0; i < rollCount; i++) {
+        diceDescriptors.push(...baseSetOfDiceDescriptors);
+    }
+
+    return diceDescriptors;
 }
 
 /** Determine the number of times the dice need to be rolled based on the selected type. */
@@ -150,7 +155,7 @@ function formatRollTypeName(rollType) {
 // function buildDiceRollObject() {
 // }
 
-function constructDiceRollString(rollName) {
+function constructDiceRollDescriptors(rollName) {
     // https://feedback.talespire.com/kb/article/talespire-url-scheme
     // Create an empty array to store the dice roll objects
     let diceRollObjects = [];
@@ -361,145 +366,3 @@ async function displayResult(resultGroup, rollId) {
             console.error("error in sending dice result", response)
         );
 }
-
-// Roll Descriptor Array
-/*
-    [
-        {
-            "name": "test-4-groups",
-            "roll": "+1d4+1d6"
-        },
-        {
-            "name": "test-4-groups",
-            "roll": "+1d4+1d6+50"
-        },
-        {
-            "name": "test-4-groups",
-            "roll": "+1d6+1d8+100"
-        },
-        {
-            "name": "test-4-groups",
-            "roll": "+1d8+1d10+200"
-        }
-    ]
-    */
-
-// Roll Event
-/*
-    {
-        "kind": "rollResults",
-        "payload": {
-            "rollId": "17179869185",
-            "clientId": "e0a85890-68af-4cc2-b55b-e11d12b89889",
-            "resultsGroups": [
-                {
-                    "name": "test-4-groups",
-                    "result": {
-                        "operator": "+",
-                        "operands": [
-                            {
-                                "kind": "d4",
-                                "results": [
-                                    3
-                                ]
-                            },
-                            {
-                                "kind": "d6",
-                                "results": [
-                                    4
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "test-4-groups",
-                    "result": {
-                        "operator": "+",
-                        "operands": [
-                            {
-                                "kind": "d4",
-                                "results": [
-                                    1
-                                ]
-                            },
-                            {
-                                "operator": "+",
-                                "operands": [
-                                    {
-                                        "kind": "d6",
-                                        "results": [
-                                            4
-                                        ]
-                                    },
-                                    {
-                                        "value": 50
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "test-4-groups",
-                    "result": {
-                        "operator": "+",
-                        "operands": [
-                            {
-                                "kind": "d6",
-                                "results": [
-                                    1
-                                ]
-                            },
-                            {
-                                "operator": "+",
-                                "operands": [
-                                    {
-                                        "kind": "d8",
-                                        "results": [
-                                            1
-                                        ]
-                                    },
-                                    {
-                                        "value": 100
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                },
-                {
-                    "name": "test-4-groups",
-                    "result": {
-                        "operator": "+",
-                        "operands": [
-                            {
-                                "kind": "d8",
-                                "results": [
-                                    4
-                                ]
-                            },
-                            {
-                                "operator": "+",
-                                "operands": [
-                                    {
-                                        "kind": "d10",
-                                        "results": [
-                                            5
-                                        ]
-                                    },
-                                    {
-                                        "value": 200
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }
-            ],
-            "gmOnly": false,
-            "quiet": true
-        }
-    }
-    */
-// https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#calls/dice/evaluatediceresultsgroup

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -1,3 +1,11 @@
+/**
+ * Executes a dice roll operation based on specified roll name and type.
+ *
+ * @param {string} rollNameParam - The name of the roll, which may be used for
+ *                                 display or logging purposes.
+ * @param {string} rollTypeParam - The type of the roll (e.g., 'normal', 'critical'),
+ *                                 which influences how the dice are rolled.
+ */
 function roll(rollNameParam, rollTypeParam) {
     let selectedType = rollTypeParam || rollTypes.normal; // Set to normal if no type is provided
     let updatedDiceGroupsData = []; // Empty the array to purge old data. We call this "updated" temporarily, but it will become the new diceGroupsData
@@ -77,6 +85,30 @@ function roll(rollNameParam, rollTypeParam) {
     }
 }
 
+/**
+ * Constructs a dice tray configuration based on the base set of dice descriptors
+ * and the roll type.
+ *
+ * This function generates a configuration for a dice tray, which is used to simulate
+ * rolling dice in TaleSpire's digital environment. It takes a base set of dice
+ * descriptors (each descriptor detailing the type and number of dice) and replicates
+ * this set according to the number of rolls dictated by the roll type. The roll type
+ * determines how many times the dice should be rolled (e.g., once for a normal roll,
+ * twice for advantage/disadvantage, etc.), and this function adjusts the dice tray
+ * configuration accordingly.
+ *
+ * The resulting array of dice descriptors represents the total set of dice to be rolled
+ * in the simulation, accounting for the roll type's requirements.
+ *
+ * @param {Array<Object>} baseSetOfDiceDescriptors - An array of objects, each describing
+ *                                                   a set of dice to be rolled (type and
+ *                                                   count).
+ * @param {string} rollType - A string indicating the type of roll (e.g., 'normal',
+ *                            'advantage', 'disadvantage'), which affects the number
+ *                            of dice rolled.
+ *
+ * @returns {Array<Object>} An array of dice descriptors adjusted for the roll type, representing the configuration of the dice tray.
+ */
 function buildDiceTrayConfiguration(baseSetOfDiceDescriptors, rollType) {
     let rollCount = getRollCount(rollType);
     let diceDescriptors = [];
@@ -88,7 +120,24 @@ function buildDiceTrayConfiguration(baseSetOfDiceDescriptors, rollType) {
     return diceDescriptors;
 }
 
-/** Determine the number of times the dice need to be rolled based on the selected type. */
+/**
+ * Determines the number of dice rolls to perform based on the roll type.
+ *
+ * This function takes a roll type as input and returns the number of times a
+ * dice should be rolled according to the specified roll type. The roll types
+ * include 'advantage', 'disadvantage', and 'bestofThree'.
+ *
+ * - For 'advantage' and 'disadvantage', the function returns 2, indicating that
+ *   two dice should be rolled.
+ * - For 'bestofThree', it returns 3, indicating that three dice should be rolled.
+ * - For any other roll type, it defaults to returning 1, indicating a single dice
+ *   roll.
+ *
+ * @param {string} rollType - The type of roll being performed, which determines
+ *                            the number of dice rolls.
+ *
+ * @returns {number} The number of times to roll the dice based on the specified roll type.
+ */
 function getRollCount(rollType) {
     switch (rollType) {
         case rollTypes.advantage:
@@ -111,6 +160,22 @@ function getRollCount(rollType) {
 // function buildCritBehavior() {
 // }
 
+/**
+ * Constructs a descriptive name for a roll based on provided parameters and
+ * optional document elements.
+ *
+ * @param {string} rollNameParam - The base name for the roll. If not provided,
+ *                                 attempts to use the value from the document's
+ *                                 "roll-name" element.
+ * @param {string} rollTypeParam - The type of the roll (e.g., "normal", "advantage",
+ *                                 "disadvantage", "crit-dice").
+ * @param {string} critBehaviorParam - The behavior of critical hits (e.g.,
+ *                                     "double-die-count", "double-die-result",
+ *                                     "double-total", "max-die", "max-plus").
+ *
+ * @returns {string} The constructed roll name, combining the base name, roll type,
+ *                   and critical hit behavior.
+ */
 function buildRollName(rollNameParam, rollTypeParam, critBehaviorParam) {
     let rollName =
         rollNameParam ||
@@ -142,6 +207,13 @@ function buildRollName(rollNameParam, rollTypeParam, critBehaviorParam) {
     return rollName;
 }
 
+/**
+ * Formats the internal roll type name into a human-readable string.
+ *
+ * @param {string} rollType - The internal identifier for the roll type.
+ *
+ * @returns {string} The human-readable string representation of the roll type.
+ */
 function formatRollTypeName(rollType) {
     const rollTypeMappings = {
         normal: "Normal",
@@ -149,14 +221,42 @@ function formatRollTypeName(rollType) {
         disadvantage: "Disadvantage",
         "best-of-three": "Best of Three",
     };
+
     return rollTypeMappings[rollType] || rollType;
 }
 
 // function buildDiceRollObject() {
 // }
 
+/**
+ * Constructs an array of dice roll descriptors based on the provided roll name
+ * and dice groups data.
+ *
+ * This function iterates over each group of dice counts provided in the global
+ * `diceGroupsData` array. For each group, it constructs a string representation
+ * of the dice rolls, including the count and type of each die, and any modifiers.
+ * These strings are then used to create objects that pair the provided roll name
+ * with the constructed roll string.
+ *
+ * The function is designed to support the
+ * [Talespire URL scheme](https://feedback.talespire.com/kb/article/talespire-url-scheme)
+ * for dice rolls, allowing these descriptors to be used for generating URLs that
+ * trigger specific dice rolls within the Talespire game.
+ *
+ * Example of a dice roll object in the returned array:
+ * ```
+ * {
+ *     name: 'TEST',
+ *     roll: '+1d4+1d6+5'
+ * }
+ * ```
+ *
+ * @param {string} rollName - The name to be associated with each dice roll descriptor.
+ *
+ * @returns {Array<Object>} An array of objects, each containing a `name` and a `roll`
+ *                          string that describes the dice roll.
+ */
 function constructDiceRollDescriptors(rollName) {
-    // https://feedback.talespire.com/kb/article/talespire-url-scheme
     // Create an empty array to store the dice roll objects
     let diceRollObjects = [];
 
@@ -183,21 +283,20 @@ function constructDiceRollDescriptors(rollName) {
         diceRollObjects.push(rollObject);
     }
 
-    // Return the array of dice roll objects
-    // [
-    //     {name: 'TEST-2-Groups', roll: '+1d4'},
-    //     {name: 'TEST-2-Groups', roll: '+1d6+100'},
-    //     ...
-    // ]
-
     return diceRollObjects;
 }
 
-// Doesn't handle any non-normal roll types
+/**
+ * Handles the processing of roll events, including roll results and roll removals.
+ *
+ * [onRollResults handler](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#subscriptions/dice/onrollresults)
+ *
+ * @param {Object} rollEvent - An object representing a roll event, containing a
+ *                             payload with the roll ID and other relevant information.
+ *
+ * @returns {Promise<void>} A promise that resolves once the roll event has been processed.
+ */
 async function handleRollResult(rollEvent) {
-    // https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#subscriptions/dice/onrollresults
-    // https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollresults
-
     if (trackedRollIds[rollEvent.payload.rollId] == undefined) {
         return;
     }
@@ -214,6 +313,14 @@ async function handleRollResult(rollEvent) {
     }
 }
 
+/**
+ * Checks if the given event name corresponds to a valid TaleSpire roll event.
+ *
+ * @param {string} eventName - The name of the event to check for validity.
+ *
+ * @returns {boolean} True if the event name is valid (matches 'rollResults'
+ *                    or 'rollRemoved'), otherwise false.
+ */
 function isValidRollEvent(eventName) {
     if (
         eventName == rollEvents.rollResults ||
@@ -225,10 +332,32 @@ function isValidRollEvent(eventName) {
     return false;
 }
 
+/**
+ * Processes a roll removed event and removes a roll from the tracked
+ * rolls collection.
+ *
+ * [rollRemoved event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollremoved)
+ *
+ * @param {Object} rollEvent - An object representing a roll removal
+ *                             event, containing the payload with the
+ *                             roll ID to be removed.
+ */
 function handleRollRemovedEvent(rollEvent) {
     delete trackedRollIds[rollEvent.payload.rollId];
 }
 
+/**
+ * Processes a roll results event and applies specific roll handling based on
+ * the roll type and critical hit behavior.
+ *
+ * [rollResults event](https://symbiote-docs.talespire.com/api_doc_v0_1.md.html#types/rollresults)
+ *
+ * @param {Object} rollEvent - An object representing a roll event, containing the
+ *                             payload with roll details.
+ *
+ * @returns {Promise<void>} A promise that resolves when the roll results have been
+ *                          processed and displayed.
+ */
 async function handleRollResultsEvent(rollEvent) {
     let roll = rollEvent.payload;
     let resultGroup = {};
@@ -261,15 +390,56 @@ async function handleRollResultsEvent(rollEvent) {
     displayResult(resultGroup, roll.rollId);
 }
 
+/**
+ * Handle the calculation of roll results under the advantage condition.
+ *
+ * @param {Object} roll             - An object representing a roll, which contains an array of
+ *                                    results groups.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array representing the
+ *                           set of roll results with the highest sum.
+ */
 async function handleAdvantageRoll(roll) {
     return await handleAdvantageDisadvantageRoll(roll, true);
 }
 
+/**
+ * Handle the calculation of roll results under the disadvantage condition.
+ *
+ * @param {Object} roll             - An object representing a roll, which contains an array of
+ *                                    results groups.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array representing the
+ *                           set of roll results with the lowest sum.
+ */
 async function handleDisadvantageRoll(roll) {
     return await handleAdvantageDisadvantageRoll(roll, false);
 }
 
+/**
+ * Handles the calculation of roll results under advantage or disadvantage conditions.
+ *
+ * This function takes a roll object and a boolean indicating whether the roll is
+ * under advantage or disadvantage conditions. It divides the roll's results into
+ * two equal sets. If the number of results groups is less than 2 or not even, it
+ * returns the original results groups. It then calculates the sum of each set.
+ * Under advantage conditions, it returns the set with the higher sum; under disadvantage
+ * conditions, it returns the set with the lower sum.
+ *
+ * @param {Object} roll             - An object representing a roll, which contains an array of
+ *                                    results groups.
+ * @param {boolean} isAdvantage     - A boolean indicating if the roll is under advantage (true)
+ *                                    or disadvantage (false) conditions.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array representing the
+ *                           set of roll results with either the highest sum (advantage)
+ *                           or the lowest sum (disadvantage).
+ */
 async function handleAdvantageDisadvantageRoll(roll, isAdvantage) {
+    if (roll.resultsGroups.length < 2 || roll.resultsGroups.length % 2 != 0) {
+        return roll.resultsGroups;
+    }
+
     let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 2;
 
     let firstSetOfGroups = roll.resultsGroups.slice(
@@ -302,7 +472,30 @@ async function handleAdvantageDisadvantageRoll(roll, isAdvantage) {
     return setWithLowestSum;
 }
 
+/**
+ * Processes a roll containing multiple groups of roll results and selects the
+ * best set of results based on their sum.
+ *
+ * This function divides the roll's results into three equal sets and calculates
+ * the sum of each set. It then compares these sums to determine which set has
+ * the highest total sum. If the number of results groups is not a multiple of
+ * three or is less than three, the function returns the original roll results
+ * groups without modification.
+ *
+ * @param {Object} roll - An object representing a roll, which contains an array
+ *                        of results groups.
+ *
+ * @returns {Promise<Array>} A promise that resolves to an array representing the
+ *                           set of roll results with the highest sum. If the input
+ *                           does not meet the required conditions (e.g., not
+ *                           divisible by three, less than three groups), it returns
+ *                           the original array of roll results groups.
+ */
 async function handleBestOfThreeRoll(roll) {
+    if (roll.resultsGroups.length < 3 || roll.resultsGroups.length % 3 != 0) {
+        return roll.resultsGroups;
+    }
+
     let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 3;
     let startingIndexOfThirdSetOfGroups = startingIndexOfSecondSetOfGroups * 2;
 
@@ -339,12 +532,18 @@ async function handleBestOfThreeRoll(roll) {
 /**
  * Calculates the total sum of multiple groups of dice roll results.
  *
- * This function takes an array of roll results groups, where each group represents a collection of dice roll results.
- * It asynchronously evaluates the sum of each group using a provided evaluation function (`TS.dice.evaluateDiceResultsGroup`),
- * then calculates and returns the total sum of these group sums.
+ * This function takes an array of roll results groups, where each group
+ * represents a collection of dice roll results. It asynchronously evaluates
+ * the sum of each group using a provided evaluation function
+ * (`TS.dice.evaluateDiceResultsGroup`), then calculates and returns the total
+ * sum of these group sums.
  *
- * @param {Array} rollResultsGroups - An array of roll results groups, where each group is a collection that can be evaluated into a sum.
- * @returns {Promise<number>} A promise that resolves to the total sum of the evaluated sums of each group in `rollResultsGroups`.
+ * @param {Array} rollResultsGroups - An array of roll results groups, where
+ *                                    each group is a collection that can be
+ *                                    evaluated into a sum.
+ *
+ * @returns {Promise<number>} A promise that resolves to the total sum of the
+ *                            evaluated sums of each group in `rollResultsGroups`.
  */
 async function getSumOfRollResultsGroups(rollResultsGroups) {
     let sums = [];

--- a/scripts/taleSpireSubscriptionHandlers.js
+++ b/scripts/taleSpireSubscriptionHandlers.js
@@ -1,0 +1,9 @@
+async function handleRollResult(rollEvent) {
+    await rollsModule.handleRollResult(rollEvent);
+}
+
+async function onStateChangeEvent(msg) {
+    if (msg.kind === "hasInitialized") {
+        loadGlobalSettings();
+    }
+}

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -1,21 +1,32 @@
-
-document.addEventListener('DOMContentLoaded', updateDiceGroupsData);
-document.addEventListener('DOMContentLoaded', sortSavedRolls);
+document.addEventListener("DOMContentLoaded", updateDiceGroupsData);
+document.addEventListener("DOMContentLoaded", sortSavedRolls);
+document
+    .getElementById("save-rolls-button")
+    .addEventListener("click", saveRollsToLocalStorage);
+document
+    .getElementById("load-rolls-button")
+    .addEventListener("click", loadRollsFromLocalStorage);
 
 function updateDiceGroupsData() {
     diceGroupsData = [];
 
-    const diceGroupElements = document.querySelectorAll('.dice-selection');
-    diceGroupElements.forEach(groupElement => {
+    const diceGroupElements = document.querySelectorAll(".dice-selection");
+    diceGroupElements.forEach((groupElement) => {
         const groupId = groupElement.id;
         const groupDiceCounts = {};
 
-        diceTypes.forEach(diceType => {
-            const countElement = groupElement.querySelector(`.counter-overlay[id$="${groupId}-${diceType}-counter-value"]`);
-            groupDiceCounts[diceType] = countElement ? parseInt(countElement.textContent, 10) : 0;
+        diceTypes.forEach((diceType) => {
+            const countElement = groupElement.querySelector(
+                `.counter-overlay[id$="${groupId}-${diceType}-counter-value"]`
+            );
+            groupDiceCounts[diceType] = countElement
+                ? parseInt(countElement.textContent, 10)
+                : 0;
         });
 
-        const modElement = groupElement.querySelector(`.mod-counter-overlay[id$="${groupId}-mod-counter-value"]`);
+        const modElement = groupElement.querySelector(
+            `.mod-counter-overlay[id$="${groupId}-mod-counter-value"]`
+        );
         groupDiceCounts.mod = modElement ? parseInt(modElement.value, 10) : 0;
 
         diceGroupsData.push(groupDiceCounts);
@@ -23,10 +34,10 @@ function updateDiceGroupsData() {
 }
 
 function increment(type) {
-    const [groupId, diceType] = type.split('-');
+    const [groupId, diceType] = type.split("-");
     const counterId = `${groupId}-${diceType}-counter-value`;
     const counter = document.getElementById(counterId);
-    
+
     if (counter) {
         let currentValue = parseInt(counter.textContent, 10);
         if (currentValue < 50) {
@@ -34,12 +45,12 @@ function increment(type) {
             updateDiceGroupsData();
         }
     } else {
-        console.error('Counter element not found:', counterId);
+        console.error("Counter element not found:", counterId);
     }
 }
 
 function decrement(type) {
-    const [groupId, diceType] = type.split('-');
+    const [groupId, diceType] = type.split("-");
     const counterId = `${groupId}-${diceType}-counter-value`;
     const counter = document.getElementById(counterId);
 
@@ -50,30 +61,30 @@ function decrement(type) {
             updateDiceGroupsData();
         }
     } else {
-        console.error('Counter element not found:', counterId);
+        console.error("Counter element not found:", counterId);
     }
 }
 
-function negativeMod(modId) { 
-    const counterId = modId + '-counter-value';
+function negativeMod(modId) {
+    const counterId = modId + "-counter-value";
     const counter = document.getElementById(counterId);
 
     if (counter) {
-        let currentValue = parseInt(counter.value, 10); 
+        let currentValue = parseInt(counter.value, 10);
         counter.value = currentValue - 1;
     } else {
-        console.error('Modifier counter element not found:', counterId);
+        console.error("Modifier counter element not found:", counterId);
     }
 }
 
 function addDiceGroup() {
-    const diceGroup = document.createElement('div');
-    diceGroup.className = 'dice-selection';
+    const diceGroup = document.createElement("div");
+    diceGroup.className = "dice-selection";
     const RollGroup = diceGroupsData.length;
     diceGroup.id = `${RollGroup}`;
-    let diceHTML = '';
+    let diceHTML = "";
 
-    diceTypes.forEach(type => {
+    diceTypes.forEach((type) => {
         diceHTML += `
             <div class="dice-counter unselectable" id="${RollGroup}-${type}-counter">
             <i class="ts-icon-${type} ts-icon-large" onclick="increment('${RollGroup}-${type}')" oncontextmenu="decrement('${RollGroup}-${type}'); return false;"></i>
@@ -95,7 +106,7 @@ function addDiceGroup() {
     diceGroup.innerHTML = diceHTML;
     diceGroupsData.push(RollGroup);
     updateDiceGroupsData();
-    document.querySelector('.content-col-dice').appendChild(diceGroup);
+    document.querySelector(".content-col-dice").appendChild(diceGroup);
 }
 
 function removeDiceGroup() {
@@ -106,66 +117,88 @@ function removeDiceGroup() {
         if (diceGroup) {
             diceGroup.remove();
             diceGroupsData.splice(lastGroupId, 1);
-            console.log('Row removed:', diceGroup);
+            console.log("Row removed:", diceGroup);
         } else {
-            console.error('Row element not found:', lastGroupId);
+            console.error("Row element not found:", lastGroupId);
         }
     } else {
-        console.warn('No rows left to remove.');
+        console.warn("No rows left to remove.");
     }
 }
 
-function sortSavedRolls() { 
-    const sortOption = document.getElementById('sort-options').value;
-    const savedRollsContainer = document.querySelector('.saved-rolls-container');
+function sortSavedRolls() {
+    const sortOption = document.getElementById("sort-options").value;
+    const savedRollsContainer = document.querySelector(
+        ".saved-rolls-container"
+    );
     let savedRollsToDisplay = savedInVault.slice();
 
     switch (sortOption) {
-        case 'newest':
+        case "newest":
             savedRollsToDisplay.reverse();
             break;
-        case 'nameAsc':
-            savedRollsToDisplay.sort((a, b) => a.querySelector('.roll-entry-label').textContent.localeCompare(b.querySelector('.roll-entry-label').textContent));
+        case "nameAsc":
+            savedRollsToDisplay.sort((a, b) =>
+                a
+                    .querySelector(".roll-entry-label")
+                    .textContent.localeCompare(
+                        b.querySelector(".roll-entry-label").textContent
+                    )
+            );
             break;
-        case 'nameDesc':
-            savedRollsToDisplay.sort((a, b) => b.querySelector('.roll-entry-label').textContent.localeCompare(a.querySelector('.roll-entry-label').textContent));
+        case "nameDesc":
+            savedRollsToDisplay.sort((a, b) =>
+                b
+                    .querySelector(".roll-entry-label")
+                    .textContent.localeCompare(
+                        a.querySelector(".roll-entry-label").textContent
+                    )
+            );
             break;
-        case 'all':
+        case "all":
             break;
     }
 
-    savedRollsContainer.innerHTML = '';
-    savedRollsToDisplay.forEach(roll => savedRollsContainer.appendChild(roll));
+    savedRollsContainer.innerHTML = "";
+    savedRollsToDisplay.forEach((roll) =>
+        savedRollsContainer.appendChild(roll)
+    );
 }
 
-function deleteSavedRoll(element) { 
-    const rollEntry = element.closest('.saved-roll-entry');
+function deleteSavedRoll(element) {
+    const rollEntry = element.closest(".saved-roll-entry");
     rollEntry.remove();
-    savedInVault = savedInVault.filter(roll => roll !== rollEntry);
+    savedInVault = savedInVault.filter((roll) => roll !== rollEntry);
 
-    if (fetchSetting('auto-save')) {
+    if (fetchSetting("auto-save")) {
         saveRollsToLocalStorage();
-    }else{
-        disableButtonById('load-rolls-button', false);
-        disableButtonById('save-rolls-button', false);
+    } else {
+        disableButtonById("load-rolls-button", false);
+        disableButtonById("save-rolls-button", false);
     }
 }
 
-function save() { 
-    const rollName = document.getElementById('roll-name').value;
-    const diceGroupElements = document.querySelectorAll('.dice-selection');
+function save() {
+    const rollName = document.getElementById("roll-name").value;
+    const diceGroupElements = document.querySelectorAll(".dice-selection");
 
     savedDiceGroups = []; // Clear the array before saving new data to remove stale data
 
-    diceGroupElements.forEach(groupElement => {
+    diceGroupElements.forEach((groupElement) => {
         const diceGroup = {};
 
-        diceTypes.forEach(diceType => {
-            const countElement = groupElement.querySelector(`.counter-overlay[id$="${groupElement.id}-${diceType}-counter-value"]`);
-            diceGroup[diceType] = countElement ? parseInt(countElement.textContent, 10) : 0;
+        diceTypes.forEach((diceType) => {
+            const countElement = groupElement.querySelector(
+                `.counter-overlay[id$="${groupElement.id}-${diceType}-counter-value"]`
+            );
+            diceGroup[diceType] = countElement
+                ? parseInt(countElement.textContent, 10)
+                : 0;
         });
 
-        const modElement = groupElement.querySelector(`.mod-counter-overlay[id$="${groupElement.id}-mod-counter-value"]`);
+        const modElement = groupElement.querySelector(
+            `.mod-counter-overlay[id$="${groupElement.id}-mod-counter-value"]`
+        );
         diceGroup.mod = modElement ? parseInt(modElement.value, 10) : 0;
 
         savedDiceGroups.push(diceGroup);
@@ -173,52 +206,61 @@ function save() {
 
     const stagedRoll = {
         name: rollName,
-        groups: savedDiceGroups
+        groups: savedDiceGroups,
     };
 
-    console.log('Saved roll JSON: ' + JSON.stringify(stagedRoll));
+    console.log("Saved roll JSON: " + JSON.stringify(stagedRoll));
 
     addSavedRoll(rollName, savedDiceGroups);
     saveCurrentRolls();
 
-    if (fetchSetting('auto-reset')) {
+    if (fetchSetting("auto-reset")) {
         reset();
     }
 
-    if (fetchSetting('auto-save')) {
+    if (fetchSetting("auto-save")) {
         saveRollsToLocalStorage();
     } else {
-        disableButtonById('save-rolls-button', false);
+        disableButtonById("save-rolls-button", false);
     }
 }
 
-function addSavedRoll(rollName, savedDiceGroups) { 
-    const savedRollsContainer = document.querySelector('.saved-rolls-container');
-    const rollEntry = document.createElement('div');
-    rollEntry.className = 'saved-roll-entry';
+function addSavedRoll(rollName, savedDiceGroups) {
+    const savedRollsContainer = document.querySelector(
+        ".saved-rolls-container"
+    );
+    const rollEntry = document.createElement("div");
+    rollEntry.className = "saved-roll-entry";
     rollEntry.dataset.diceCounts = JSON.stringify(savedDiceGroups);
     savedInVault.push(rollEntry);
 
-    const diceDisplay = document.createElement('div');
-    diceDisplay.className = 'roll-entry-dice';
-    
-    savedDiceGroups.forEach(diceCounts => {
+    const diceDisplay = document.createElement("div");
+    diceDisplay.className = "roll-entry-dice";
+
+    savedDiceGroups.forEach((diceCounts) => {
         const diceGroupText = Object.entries(diceCounts)
-            .filter(([diceType, count]) => count > 0 && diceType !== 'mod')
+            .filter(([diceType, count]) => count > 0 && diceType !== "mod")
             .map(([diceType, count]) => `${count}${diceType}`)
-            .join(' + ');
-    
+            .join(" + ");
+
         const modifier = diceCounts.mod;
-        const modifierText = modifier !== 0 ? `${modifier >= 0 ? '+' : ''}${modifier}` : '';
-    
-        const diceRow = document.createElement('div');
-        diceRow.className = 'dice-row';
-        diceRow.textContent = `${diceGroupText}${modifierText ? ` ${modifierText}` : ''}`;
+        const modifierText =
+            modifier !== 0 ? `${modifier >= 0 ? "+" : ""}${modifier}` : "";
+
+        const diceRow = document.createElement("div");
+        diceRow.className = "dice-row";
+        diceRow.textContent = `${diceGroupText}${
+            modifierText ? ` ${modifierText}` : ""
+        }`;
         diceDisplay.appendChild(diceRow);
     });
 
     let rollNameText = rollName;
-    if (rollNameText === "" || rollNameText === null || rollNameText === undefined) {
+    if (
+        rollNameText === "" ||
+        rollNameText === null ||
+        rollNameText === undefined
+    ) {
         rollNameText = "Unnamed Roll";
     }
 
@@ -235,46 +277,95 @@ function addSavedRoll(rollName, savedDiceGroups) {
     `;
     rollEntry.appendChild(diceDisplay);
 
-    const rowOfButtons = document.createElement('div');
-    rowOfButtons.className = 'row-buttons-container';
-    createRollButton('rolling',         rollNameText, 'normal',         savedDiceGroups, 'roll-button row-button', rowOfButtons);
-    createRollButton('disadvantage',    rollNameText, 'disadvantage',   savedDiceGroups, 'roll-button row-button', rowOfButtons);
-    createRollButton('advantage',       rollNameText, 'advantage',      savedDiceGroups, 'roll-button row-button', rowOfButtons);
-    createRollButton('best-of-three',   rollNameText, 'best-of-three',  savedDiceGroups, 'roll-button row-button', rowOfButtons);
-    createRollButton('crit',            rollNameText, 'crit-dice',      savedDiceGroups, 'roll-button row-button', rowOfButtons);
+    const rowOfButtons = document.createElement("div");
+    rowOfButtons.className = "row-buttons-container";
+    createRollButton(
+        "rolling",
+        rollNameText,
+        "normal",
+        savedDiceGroups,
+        "roll-button row-button",
+        rowOfButtons
+    );
+    createRollButton(
+        "disadvantage",
+        rollNameText,
+        "disadvantage",
+        savedDiceGroups,
+        "roll-button row-button",
+        rowOfButtons
+    );
+    createRollButton(
+        "advantage",
+        rollNameText,
+        "advantage",
+        savedDiceGroups,
+        "roll-button row-button",
+        rowOfButtons
+    );
+    createRollButton(
+        "best-of-three",
+        rollNameText,
+        "best-of-three",
+        savedDiceGroups,
+        "roll-button row-button",
+        rowOfButtons
+    );
+    createRollButton(
+        "crit",
+        rollNameText,
+        "crit-dice",
+        savedDiceGroups,
+        "roll-button row-button",
+        rowOfButtons
+    );
 
     rollEntry.appendChild(rowOfButtons);
 
     if (savedRollsContainer.firstChild) {
-        savedRollsContainer.insertBefore(rollEntry, savedRollsContainer.firstChild);
+        savedRollsContainer.insertBefore(
+            rollEntry,
+            savedRollsContainer.firstChild
+        );
     } else {
         savedRollsContainer.appendChild(rollEntry);
     }
 }
 
-function createRollButton(imageName, rollName, rollType, rollGroups, classes, parent){  
-    const rollButton = document.createElement('div');
+function createRollButton(
+    imageName,
+    rollName,
+    rollType,
+    rollGroups,
+    classes,
+    parent
+) {
+    const rollButton = document.createElement("div");
     rollButton.className = classes;
-    rollButton.onclick = function() {
-        roll(rollName, rollType, rollGroups);
+    rollButton.onclick = function () {
+        rollsModule.roll(rollName, rollType, rollGroups);
     };
-    const imageIcon = document.createElement('img');
+    const imageIcon = document.createElement("img");
     imageIcon.src = `./images/icons/${imageName}.png`;
-    imageIcon.className = 'roll-type-image';
+    imageIcon.className = "roll-type-image";
     rollButton.appendChild(imageIcon);
     parent.appendChild(rollButton);
 }
 
 function reset() {
     updateDiceGroupsData();
-    document.getElementById('roll-name').value = '';
+    document.getElementById("roll-name").value = "";
 
     diceGroupsData.forEach((group, index) => {
-        diceTypes.forEach(type => {
-            const counter = document.getElementById(`${index}-${type}-counter-value`);
-            const modCounter = document.getElementById(`${index}-mod-counter-value`);
-            if (counter) counter.textContent = '0';
-            if (modCounter) modCounter.value = '0';
+        diceTypes.forEach((type) => {
+            const counter = document.getElementById(
+                `${index}-${type}-counter-value`
+            );
+            const modCounter = document.getElementById(
+                `${index}-mod-counter-value`
+            );
+            if (counter) counter.textContent = "0";
+            if (modCounter) modCounter.value = "0";
         });
 
         if (index > 0) {
@@ -285,19 +376,9 @@ function reset() {
         }
     });
 
-    diceGroupsData.splice(1); 
+    diceGroupsData.splice(1);
 }
 
-async function onStateChangeEvent(msg){ 
-    if (msg.kind === 'hasInitialized'){
-        loadGlobalSettings();
-    }
-}
-
-function disableButtonById(id, disable = true){ 
+function disableButtonById(id, disable = true) {
     document.getElementById(id).disabled = disable;
 }
-
-// TODO: MOve these to the top of the file
-document.getElementById('save-rolls-button').addEventListener('click', saveRollsToLocalStorage);
-document.getElementById('load-rolls-button').addEventListener('click', loadRollsFromLocalStorage);

--- a/vault.html
+++ b/vault.html
@@ -141,12 +141,12 @@
             <button id="load-rolls-button" class="black-button">Load Rolls</button>
         </div>
 
+        <script type="text/javascript" src="scripts/globals.js"></script>
         <script type="text/javascript" src="scripts/settings.js"></script>
         <script type="text/javascript" src="scripts/saveLoad.js"></script>
         <script type="text/javascript" src="scripts/diceCrits.js"></script>
-        <script type="text/javascript" src="scripts/vault.js"></script>
         <script type="text/javascript" src="scripts/rolls.js"></script>
-        <script type="text/javascript" src="scripts/globals.js"></script>
+        <script type="text/javascript" src="scripts/vault.js"></script>
         <script type="text/javascript" src="scripts/taleSpireSubscriptionHandlers.js"></script>
     </body>
 </html>

--- a/vault.html
+++ b/vault.html
@@ -105,11 +105,11 @@
             </div>
             
             <div class="button-container unselectable">
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'normal',        null)"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'disadvantage',  null)"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'advantage',     null)"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'best-of-three', null)"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'crit-dice',     null)"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'normal')"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'advantage')"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'disadvantage')"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'best-of-three')"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'crit-dice')"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
             </div>
             
             <div class="button-container unselectable">

--- a/vault.html
+++ b/vault.html
@@ -105,11 +105,11 @@
             </div>
             
             <div class="button-container unselectable">
-                <button class="rolling-button" onclick="roll(null, 'normal',        null)"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
-                <button class="rolling-button" onclick="roll(null, 'disadvantage',  null)"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
-                <button class="rolling-button" onclick="roll(null, 'advantage',     null)"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
-                <button class="rolling-button" onclick="roll(null, 'best-of-three', null)"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
-                <button class="rolling-button" onclick="roll(null, 'crit-dice',     null)"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'normal',        null)"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'disadvantage',  null)"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'advantage',     null)"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'best-of-three', null)"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
+                <button class="rolling-button" onclick="rollsModule.roll(null, 'crit-dice',     null)"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
             </div>
             
             <div class="button-container unselectable">
@@ -147,5 +147,6 @@
         <script type="text/javascript" src="scripts/vault.js"></script>
         <script type="text/javascript" src="scripts/rolls.js"></script>
         <script type="text/javascript" src="scripts/globals.js"></script>
+        <script type="text/javascript" src="scripts/taleSpireSubscriptionHandlers.js"></script>
     </body>
 </html>


### PR DESCRIPTION
## Overview
This pull request updates the code to allow users to apply the advantage, disadvantage, and best of three roll type modifiers to their rolls, be they a single roll or a grouping of rolls. The PR also contains various code cleanup changes, including:
- Adding documentation comments to the rolls.js and global.js files. 
- Sequestering the roll.js code into a JavaScript module and defining the public API other areas of the code can use.
- Applying styling changes to the code. Automatically done by the VS Code extension, **Prettier - Code formatter**.

## BUG: Loaded Rolls Not Populating the Dice Tray and Throwing a foundEmptyDiceGroup Exception
Was discovered while working on this PR, but the bug was in existence prior to working on this PR. 

**Steps to reproduce:**
1. Create a dice roll. 
2. Save the dice roll. 
3. Click the Roll button for the saved dice roll. 
4. The dice tray will not be populated, and a foundEmptyDiceGroup exception will exist in the dev tools console.