### PR TITLE
merge release release/3.0 into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Check it out on [Mod.io](https://mod.io/g/talespire/m/dice-vault).
 
 # Changelog
 ```
+2.2
+- Edit buttons on saved rolls allows for modifying a saved roll without deleting it
 2.1
 - 3 critical hit modes: 1.5x total, 3x total, and 4x total
 2.0

--- a/README.md
+++ b/README.md
@@ -17,18 +17,21 @@ Check it out on [Mod.io](https://mod.io/g/talespire/m/dice-vault).
   - Saved presets are specific to the campaign. Have a preset collection for each campaign you're participating in!
   - 5 different rolling styles with 5 different common critical hit methods. These modes include a standard roll, advantage, disadvantage, best-of-3, and critical hit (configured via the settings menu).
 
+# A Note about Updating and Locally Saved Rolls
+Over time, the underlying data structure of the rolls in this symbiote has changed a few times and it's a lot of effort and trouble to try and create an updater function inside the symbiote. For this reason, encourage you to write down the rolls you need so you can recreate them after you install the update.
+
 # Changelog
 ```
-2.2
-- New feature: Named roll groups! Previously we expanded functionality to let you roll independent roll groups. Unfortunately, all the groups shared the same name according to Talespire. This has been resolved and all roll groups can have their own unique name. If no name is provided, it defaults to "Group 1", "Group 2", etc.
-- Edit buttons on saved rolls allows for modifying a saved roll without deleting it
+3.0
+- New feature: Named roll groups! Previously we expanded functionality to let you roll independent roll groups. Unfortunately, all the groups shared the same name according to Talespire. This has been resolved and all roll groups can have their own unique name. If no name is provided, it defaults to "Group 1", "Group 2", etc. This caused another change in the data structure so rolls from old versions will not roll forward from prior versions of Dice Vault.
+- Edit buttons on saved rolls allows for modifying a saved roll without deleting it!
 - Buttons have been renamed to clarify their purpose. Pin a roll only stores the roll for that play session. Save Locally stores your pinned rolls into ./localstorage. These terms will be the new nomenclature going forward. "Pin" is temporary, "Save" is permanent.
 2.1
 - 3 critical hit modes: 1.5x total, 3x total, and 4x total
 2.0
 - New feature: Roll groups! Create multiple groups of dice which do not add together. Useful for situations where dice needs to be rolled together but not all combined. "I cast Magic Missile at 3rd level dealing, three 1d4's of damage." In this situation we report three independent results with 1 throw, instead of 3d4 we do not add them together so it's three seperate results of 1d4. Useful for all kinds of situations like crossbows where the bolt deals damage and then the magical properties of an explosive bolt for example.
 - New UI to saved rolls. Instead of displaying images for dice, we know parse it down to simple and familiar roll strings, "1d4+1d6+5", or "1d20+14". You will notice saved roll cards are now much smaller allowing you to see more at one time. We will expand on this UI in future releases to further improve the UI.
-- Breaking change: the data structure we used to use in 1.3 is out. This means your old saved data will not work in 2.0. **however**, we have you covered as we built an updater function to try and upgrade your data to 2.0 format. Please report any issues with updating your data via the github issues tab.
+- Breaking change: the data structure we used to use in 1.3 is out. This means your old saved data will not work in 2.0.
 1.3
 - Added Critical Hit support with 5 different styles
 - Updated the UI to flow better with iconography
@@ -67,14 +70,6 @@ Check it out on [Mod.io](https://mod.io/g/talespire/m/dice-vault).
 
 To delete a preset, use the trash bin icon.
 
-# Before Upgrading 1.3 > 2.0+
-1. Navigate to your Symbiote directory and open the folder for Dice Vault
-2. navigate to the ./localstorage folder
-3. Copy the .json file and place it somewhere you will remember, like your desktop for example
-4. Install Dice Vault 2.0
-5. Paste the .json file into the same directory that you copied it from, though the ID of the symbiote has likely changed
-6. Once you open the Symbiote, the first time you load your data it will automatically upgrade the data to the new data format
-
 # Report Issues
 Create an issue in the github reposity on the [Issues Tab](https://github.com/JasonCostanza/Dice-Vault/issues).
 
@@ -83,11 +78,12 @@ Any information you can provide to reproducing your issue is appreciated includi
 # Roadmap
 See our github issues tab for bugs and enhancements on the roadmap.
 
+With the recent announcement of the official Dice Engine feature undergoing development, future development of Dice Vault may be postponed or carefully measured against what the Talespire team is developing. This symbiote was born in the gap of what Dice Engine (official feature) will potentially cover. At the time of writing this, we don't have full clarity on what the official feature will do in full.
+
 # Special Thanks
 [DeeForce](https://github.com/D33Force)
 [PanoramicPanda](https://github.com/PanoramicPanda)
 [kbarnett](https://github.com/kbarnett)
-
 
 # Contribor Environment Configuration
 If you wish to contribute to the project you are more than welcome to create a feature branch, add your contributions, and open a PR against `main`. To get your local environment set up, it's a pretty easy process:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Check it out on [Mod.io](https://mod.io/g/talespire/m/dice-vault).
 # Changelog
 ```
 2.2
+- New feature: Named roll groups! Previously we expanded functionality to let you roll independent roll groups. Unfortunately, all the groups shared the same name according to Talespire. This has been resolved and all roll groups can have their own unique name. If no name is provided, it defaults to "Group 1", "Group 2", etc.
 - Edit buttons on saved rolls allows for modifying a saved roll without deleting it
+- Buttons have been renamed to clarify their purpose. Pin a roll only stores the roll for that play session. Save Locally stores your pinned rolls into ./localstorage. These terms will be the new nomenclature going forward. "Pin" is temporary, "Save" is permanent.
 2.1
 - 3 critical hit modes: 1.5x total, 3x total, and 4x total
 2.0

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "name": "Dice Vault",
   "summary": "A Symbiote to roll dice in many ways",
-  "version": "2.2",
+  "version": "3.0",
   "about": {
     "website": "https://github.com/JasonCostanza/Dice-Vault",
     "authors": [

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "name": "Dice Vault",
   "summary": "A Symbiote to roll dice in many ways",
-  "version": "2.1",
+  "version": "2.2",
   "about": {
     "website": "https://github.com/JasonCostanza/Dice-Vault",
     "authors": [

--- a/scripts/dataUpgrade.js
+++ b/scripts/dataUpgrade.js
@@ -4,7 +4,7 @@
  * @param {Array} oldData - The old rolls data in 1.3 format.
  * @returns {Array} The upgraded rolls data in 2.0 format.
  */
-function upgradeRollsData(oldData) {
+function upgradeRollsData1_3To2_0(oldData) {
     return oldData.map(oldRoll => ({
         name: oldRoll.name,
         type: oldRoll.type,
@@ -16,6 +16,25 @@ function upgradeRollsData(oldData) {
             d12: parseInt(oldRoll.counts.d12) || 0,
             d20: parseInt(oldRoll.counts.d20) || 0,
             mod: parseInt(oldRoll.counts.mod) || 0
+        }]
+    }));
+}
+
+function upgradeRollsData2_0To2_x(oldData) {
+    return oldData.map(oldRoll => ({
+        name: oldRoll.name,
+        type: oldRoll.type,
+        groups: [{
+            name: "Group 1", // Default name for the single group in old format
+            diceCounts: {
+                d4: parseInt(oldRoll.counts.d4) || 0,
+                d6: parseInt(oldRoll.counts.d6) || 0,
+                d8: parseInt(oldRoll.counts.d8) || 0,
+                d10: parseInt(oldRoll.counts.d10) || 0,
+                d12: parseInt(oldRoll.counts.d12) || 0,
+                d20: parseInt(oldRoll.counts.d20) || 0,
+                mod: parseInt(oldRoll.counts.mod) || 0
+            }
         }]
     }));
 }

--- a/scripts/diceCrits.js
+++ b/scripts/diceCrits.js
@@ -1,9 +1,3 @@
-/**
- * Multiplies the total of all values in the result groups by 1.5, rounding down.
- * 
- * @param {Array<Object>} resultGroups - An array of result group objects.
- * @returns {Array<Object>} A new array of result groups with totals multiplied by 1.5 and rounded down.
- */
 function onePointFiveTotal(result) {
     if (Array.isArray(result)) {
         return result.map(group => ({
@@ -18,21 +12,21 @@ function onePointFiveResultsRecursive(result) {
     if (result.kind && Array.isArray(result.results)) {
         return {
             ...result,
-            results: result.results.map(r => Math.floor(r * 1.5)), // Round down with Math.floor
-            total: Math.floor((result.total || 0) * 1.5), // Round down with Math.floor
+            results: result.results.map(r => Math.floor(r * 1.5)),
+            total: Math.floor((result.total || 0) * 1.5),
             description: `Critical Hit! Total multiplied by 1.5 (rounded down)`
         };
     } else if (result.operator && Array.isArray(result.operands)) {
         return {
             ...result,
             operands: result.operands.map(onePointFiveResultsRecursive),
-            total: Math.floor((result.total || 0) * 1.5), // Round down with Math.floor
+            total: Math.floor((result.total || 0) * 1.5),
             description: `Critical Hit! Total multiplied by 1.5 (rounded down)`
         };
     } else if (result.value !== undefined) {
         return {
             ...result,
-            value: Math.floor(result.value * 1.5) // Round down with Math.floor
+            value: Math.floor(result.value * 1.5)
         };
     }
     return result;
@@ -117,17 +111,19 @@ function doubleResultsRecursive(result) {
     if (result.kind && Array.isArray(result.results)) {
         return {
             ...result,
-            results: result.results.map(r => r * 2)
+            results: result.results.map(r => r * 2),
+            total: (result.total || 0) * 2,
+            description: `Critical Hit! Dice results doubled`
         };
     } else if (result.operator && Array.isArray(result.operands)) {
         return {
             ...result,
-            operands: result.operands.map(doubleResultsRecursive)
+            operands: result.operands.map(doubleResultsRecursive),
+            total: (result.total || 0) * 2,
+            description: `Critical Hit! Dice results doubled`
         };
-    } else {
-        console.log('Encountered non-dice operand, returning unchanged:', result);
-        return result;
     }
+    return result;
 }
 
 /**
@@ -303,21 +299,13 @@ function doubleTotal(result) {
 }
 
 function doubleDiceResults(result) {
-    if (result.operator && result.operands) {
-        return {
-            ...result,
-            operands: result.operands.map(doubleDiceResults),
-            total: calculateTotal(result),
-            description: `Critical Hit! Dice results doubled`
-        };
-    } else if (result.results) {
-        return {
-            ...result,
-            results: result.results.map(val => val * 2),
-            total: result.results.reduce((sum, val) => sum + val * 2, 0)
-        };
+    if (Array.isArray(result)) {
+        return result.map(group => ({
+            ...group,
+            result: doubleResultsRecursive(group.result)
+        }));
     }
-    return result;
+    return doubleResultsRecursive(result);
 }
 
 function maximizeDice(result) {

--- a/scripts/diceCrits.js
+++ b/scripts/diceCrits.js
@@ -42,16 +42,15 @@ function onePointFiveResultsRecursive(result) {
  * @returns {Array<Object>} A new array of objects with doubled dice counts.
  */
 function doubleDiceCounts(rollGroups) {
-    return rollGroups.map(diceCounts => {
-        let doubledDiceCounts = {};
-        for (const [die, count] of Object.entries(diceCounts)) {
+    return rollGroups.map(group => {
+        let doubledGroup = { ...group };
+        doubledGroup.diceCounts = { ...group.diceCounts };
+        for (const [die, count] of Object.entries(group.diceCounts)) {
             if (die !== 'mod') {
-                doubledDiceCounts[die] = String(parseInt(count, 10) * 2);
-            } else {
-                doubledDiceCounts[die] = count;
+                doubledGroup.diceCounts[die] = count * 2;
             }
         }
-        return doubledDiceCounts;
+        return doubledGroup;
     });
 }
 

--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -1,3 +1,5 @@
+let overwriteConfirmed = false;
+
 /**
  * Array of arrays, contains diceGroupsData[] arrays as elements which is
  * everything saved to JSON ./localstorage/ inside one array.

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -619,43 +619,42 @@ const rollsModule = (function () {
         }
     
         return resultGroups.map(group => {
-            if (critBehavior === "double-total") {
-                return {
-                    ...group,
-                    result: doubleTotal(group.result)
-                };
-            } else if (critBehavior === "double-die-result") {
-                return {
-                    ...group,
-                    result: doubleDiceResults(group.result)
-                };
-            } else if (critBehavior === "max-die") {
-                return {
-                    ...group,
-                    result: maximizeDice(group.result)
-                };
-            } else if (critBehavior === "max-plus") {
-                return {
-                    ...group,
-                    result: addMaxDieForEachKind(group.result)
-                };
-            } else if (critBehavior === "triple-total") {
-                return {
-                    ...group,
-                    result: tripleTotal(group.result)
-                };
-            } else if (critBehavior === "quadruple-total") {
-                return {
-                    ...group,
-                    result: quadrupleTotal(group.result)
-                };
-            } else if (critBehavior === "one-point-five-total") {
-                return {
-                    ...group,
-                    result: onePointFiveTotal(group.result)
-                };
+            let modifiedResult;
+            switch (critBehavior) {
+                case "double-total":
+                    modifiedResult = doubleTotal(group.result);
+                    break;
+                case "double-die-result":
+                    modifiedResult = doubleDiceResults(group.result);
+                    break;
+                case "max-die":
+                    modifiedResult = maximizeDice(group.result);
+                    break;
+                case "max-plus":
+                    modifiedResult = addMaxDieForEachKind(group.result);
+                    break;
+                case "triple-total":
+                    modifiedResult = tripleTotal(group.result);
+                    break;
+                case "quadruple-total":
+                    modifiedResult = quadrupleTotal(group.result);
+                    break;
+                case "one-point-five-total":
+                    modifiedResult = onePointFiveTotal(group.result);
+                    break;
+                default:
+                    modifiedResult = group.result;
             }
-            return group;
+    
+            // Update the group name to include "Critical" if it's a crit behavior
+            if (critBehavior !== "none") {
+                group.name = group.name ? `Critical: ${group.name}` : "Critical Roll";
+            }
+    
+            return {
+                ...group,
+                result: modifiedResult
+            };
         });
     }
     
@@ -677,10 +676,11 @@ const rollsModule = (function () {
         try {
             console.log(`Displaying results for roll ID: ${rollId}`);
     
-            // Ensure each result group has a name
+            // Ensure each result group has a name and description
             const namedResultGroups = resultGroups.map((group, index) => ({
                 ...group,
-                name: group.name || `Group ${index + 1}`
+                name: group.name || `Group ${index + 1}`,
+                description: group.description || group.result.description || ''
             }));
     
             console.log('Named Result Groups:', JSON.stringify(namedResultGroups, null, 2));

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -20,7 +20,12 @@ const rollsModule = (function () {
         let selectedType = rollTypeParam || rollTypes.normal;
         let updatedDiceGroupsData = groupsData || [];
     
-        if (!groupsData) {
+        if (!Array.isArray(updatedDiceGroupsData)) {
+            console.error('Invalid dice groups data:', updatedDiceGroupsData);
+            return;
+        }
+    
+        if (updatedDiceGroupsData.length === 0) {
             // If no groupsData provided, use the current UI state
             const diceGroupElements = document.querySelectorAll(".dice-selection");
             diceGroupElements.forEach((groupElement) => {

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -396,26 +396,36 @@ const rollsModule = (function () {
      */
     async function getReportableRollResultsGroup(roll, rollType) {
         let resultGroups;
-
+    
         switch (rollType) {
             case rollTypes.advantage:
                 resultGroups = await handleAdvantageRoll(roll);
+                resultGroups = addPrefixToGroupNames(resultGroups, "With Advantage: ");
                 break;
-
+    
             case rollTypes.disadvantage:
                 resultGroups = await handleDisadvantageRoll(roll);
+                resultGroups = addPrefixToGroupNames(resultGroups, "With Disadvantage: ");
                 break;
-
+    
             case rollTypes.bestofThree:
                 resultGroups = await handleBestOfThreeRoll(roll);
+                resultGroups = addPrefixToGroupNames(resultGroups, "Best of Three: ");
                 break;
-
+    
             default:
                 resultGroups = roll.resultsGroups;
         }
-
+    
         // Ensure we always return an array, even if it's a single group
         return Array.isArray(resultGroups) ? resultGroups : [resultGroups];
+    }
+
+    function addPrefixToGroupNames(resultGroups, prefix) {
+        return resultGroups.map(group => ({
+            ...group,
+            name: group.name ? `${prefix}${group.name}` : prefix.trim()
+        }));
     }
 
     /**
@@ -470,37 +480,26 @@ const rollsModule = (function () {
         ) {
             return roll.resultsGroups;
         }
-
+    
         let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 2;
-
+    
         let firstSetOfGroups = roll.resultsGroups.slice(
             0,
             startingIndexOfSecondSetOfGroups
         );
-
+    
         let secondSetOfGroups = roll.resultsGroups.slice(
             startingIndexOfSecondSetOfGroups
         );
-
+    
         let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
         let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
-
-        let setWithHighestSum = [];
-        let setWithLowestSum = [];
-
-        if (sumOfFirstSet >= sumOfSecondSet) {
-            setWithHighestSum = firstSetOfGroups;
-            setWithLowestSum = secondSetOfGroups;
-        } else {
-            setWithHighestSum = secondSetOfGroups;
-            setWithLowestSum = firstSetOfGroups;
-        }
-
-        if (isAdvantage == true) {
-            return setWithHighestSum;
-        }
-
-        return setWithLowestSum;
+    
+        let chosenSet = (isAdvantage ? 
+            (sumOfFirstSet >= sumOfSecondSet ? firstSetOfGroups : secondSetOfGroups) :
+            (sumOfFirstSet <= sumOfSecondSet ? firstSetOfGroups : secondSetOfGroups));
+    
+        return chosenSet;
     }
 
     /**

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -347,7 +347,7 @@ const rollsModule = (function () {
     async function handleRollResultsEvent(rollEvent) {
         let roll = rollEvent.payload;
         let resultGroups = [];
-
+    
         if (roll.resultsGroups != undefined) {
             let rollInfo = trackedRollIds[roll.rollId];
             if (rollInfo) {
@@ -356,12 +356,12 @@ const rollsModule = (function () {
                         roll,
                         rollInfo.type
                     );
-
+    
                     resultGroups = applyCritBehaviorToRollResultsGroup(
                         resultGroups,
                         rollInfo.critBehavior
                     );
-
+    
                     await displayResults(resultGroups, roll.rollId);
                     console.log('Results displayed successfully');
                 } catch (error) {

--- a/scripts/saveLoad.js
+++ b/scripts/saveLoad.js
@@ -33,12 +33,18 @@ function saveRollsToLocalStorage() {
     let rollsData = [];
     document.querySelectorAll('.saved-roll-entry').forEach(entry => {
         let groupCount = parseInt(entry.dataset.groupCount, 10) || 1;
-        let counts = [];
+        let groups = [];
         for (let i = 0; i < groupCount; i++) {
-            let groupData = entry.querySelector(`.dice-group[data-group-index="${i}"]`)?.dataset.diceCounts;
-            if (groupData) {
+            let groupElement = entry.querySelector(`.dice-group[data-group-index="${i}"]`);
+            if (groupElement) {
+                let groupName = groupElement.textContent.split(':')[0].trim();
+                let diceCountsData = groupElement.dataset.diceCounts;
                 try {
-                    counts.push(JSON.parse(groupData));
+                    let diceCounts = JSON.parse(diceCountsData);
+                    groups.push({
+                        name: groupName,
+                        diceCounts: diceCounts
+                    });
                 } catch (e) {
                     console.error(`Error parsing dice counts for group ${i}:`, e);
                     continue;
@@ -48,7 +54,7 @@ function saveRollsToLocalStorage() {
         let rollData = {
             name: entry.querySelector('.roll-entry-label').textContent.trim(),
             type: entry.dataset.rollType,
-            counts: counts
+            groups: groups
         };
         rollsData.push(rollData);
     });
@@ -72,7 +78,7 @@ async function loadRollsFromLocalStorage() {
         const rollsJson = await TS.localStorage.campaign.getBlob();
         let rollsData = JSON.parse(rollsJson || '[]');
         rollsData.forEach(rollData => {
-            addSavedRoll(rollData.name, rollData.counts, rollData.type);
+            addSavedRoll(rollData.name, rollData.groups, rollData.type);
         });
         disableButtonById('load-rolls-button');
         if (!fetchSetting('auto-save')){

--- a/scripts/saveLoad.js
+++ b/scripts/saveLoad.js
@@ -16,7 +16,7 @@ function updateAutoButtons(){
         document.getElementById('load-rolls-button').innerText = 'Auto-Loading';
         disableButtonById('load-rolls-button');
     }else{
-        document.getElementById('load-rolls-button').innerText = 'Load Rolls';
+        document.getElementById('load-rolls-button').innerText = 'Load Save';
         disableButtonById('load-rolls-button', false);
     }
 
@@ -24,7 +24,7 @@ function updateAutoButtons(){
         document.getElementById('save-rolls-button').innerText = 'Auto-Saving';
         disableButtonById('save-rolls-button');
     } else {
-        document.getElementById('save-rolls-button').innerText = 'Save Rolls';
+        document.getElementById('save-rolls-button').innerText = 'Save Locally';
         disableButtonById('save-rolls-button', false);
     }
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -70,7 +70,7 @@ async function handleRetrieveBackup() {
             const textArea = document.createElement('textarea');
             textArea.value = backupString;
             textArea.style.width = '100%';
-            textArea.style.height = '200px';
+            textArea.style.height = '80%';
             textArea.readOnly = true;
 
             // Create a modal or dialog to display the backup data
@@ -79,7 +79,7 @@ async function handleRetrieveBackup() {
             modal.style.left = '10%';
             modal.style.top = '10%';
             modal.style.width = '80%';
-            modal.style.height = '80%';
+            modal.style.height = '50%';
             modal.style.backgroundColor = 'white';
             modal.style.padding = '20px';
             modal.style.border = '1px solid black';

--- a/scripts/taleSpireSubscriptionHandlers.js
+++ b/scripts/taleSpireSubscriptionHandlers.js
@@ -72,21 +72,19 @@ async function checkAndUpgradeRollsData() {
             return null;
         }
 
-        originalData = savedData; // Store the original data
+        originalData = savedData;
         const parsedData = JSON.parse(savedData);
 
-        if (Array.isArray(parsedData) && parsedData.length > 0 && !Array.isArray(parsedData[0].counts)) {
+        if (Array.isArray(parsedData) && parsedData.length > 0 && !parsedData[0].groups) {
             console.warn('Outdated rolls data format detected. Initiating upgrade process...');
             
-            // Create a backup of the original data
             await TS.localStorage.campaign.setBlob(JSON.stringify({
                 backupData: parsedData,
                 backupTimestamp: new Date().toISOString()
             }), 'dice_vault_data_backup');
 
-            const upgradedData = upgradeRollsData(parsedData);
+            const upgradedData = upgradeRollsData2_0To2_x(parsedData);
 
-            // Save the upgraded data
             await TS.localStorage.campaign.setBlob(JSON.stringify(upgradedData));
 
             console.warn('Rolls data upgrade completed successfully. ' +

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -318,7 +318,10 @@ function save() {
         saveRollsToLocalStorage();
     } else {
         disableButtonById("save-rolls-button", false);
+        disableButtonById("load-rolls-button", false);
     }
+    
+    updateAutoButtons();
 }
 
 function showOverwriteModal(rollName) {

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -317,7 +317,10 @@ function save() {
 }
 
 function showOverwriteModal(rollName) {
+    toggleOverlay(true);
+
     const modal = document.createElement('div');
+    modal.className = 'overwrite-modal';
     modal.style.position = 'fixed';
     modal.style.left = '50%';
     modal.style.top = '50%';
@@ -341,13 +344,36 @@ function showOverwriteModal(rollName) {
 
     document.getElementById('overwrite-yes').addEventListener('click', () => {
         document.body.removeChild(modal);
+        toggleOverlay(false);
         overwriteConfirmed = true;  // Set the flag to true
         save(); // Call save() again to proceed with saving
     });
 
     document.getElementById('overwrite-no').addEventListener('click', () => {
         document.body.removeChild(modal);
+        toggleOverlay(false);
     });
+}
+
+function toggleOverlay(show) {
+    if (show) {
+        const overlay = document.createElement('div');
+        overlay.id = 'modal-overlay';
+        overlay.style.position = 'fixed';
+        overlay.style.top = '0';
+        overlay.style.left = '0';
+        overlay.style.width = '100%';
+        overlay.style.height = '100%';
+        overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.5)';
+        overlay.style.zIndex = '999';
+        overlay.style.pointerEvents = 'auto';  // This allows the overlay to receive mouse events
+        document.body.appendChild(overlay);
+    } else {
+        const overlay = document.getElementById('modal-overlay');
+        if (overlay) {
+            overlay.remove();
+        }
+    }
 }
 
 function rollNameExists(rollName) {

--- a/scripts/vault.js
+++ b/scripts/vault.js
@@ -521,6 +521,7 @@ function startEditingSavedRoll(elementOrId) {
         const groupNameInput = document.getElementById(`group-${i}-name`);
         if (groupNameInput) {
             groupNameInput.value = groupName;
+            groupNameInput.classList.add('editing');  // Add 'editing' class to group name input
         }
         
         diceTypes.forEach(diceType => {
@@ -543,7 +544,7 @@ function startEditingSavedRoll(elementOrId) {
     if (editButton) editButton.classList.add('editing');
 }
 
-function editSavedRoll(elementOrId ) {
+function editSavedRoll(elementOrId) {
     let rollEntry;
     let rollId;
 
@@ -657,7 +658,8 @@ function abortEditing() {
         const editingRollEntry = document.querySelector(`.saved-roll-entry[data-roll-id="${editingRollId}"]`);
         if (editingRollEntry) {
             editingRollEntry.classList.remove('editing');
-            editingRollEntry.querySelector('.edit-roll').classList.remove('editing');
+            const editButton = editingRollEntry.querySelector('.edit-roll');
+            if (editButton) editButton.classList.remove('editing');
         }
         delete document.body.dataset.editingRollId;
     }
@@ -666,17 +668,23 @@ function abortEditing() {
     const rollNameInput = document.getElementById('roll-name');
     rollNameInput.classList.remove('editing');
 
-    // Remove editing class from Add Group and Remove Group buttons
-    const addGroupButton = document.getElementById('add-group-button');
-    const removeGroupButton = document.getElementById('remove-group-button');
-    if (addGroupButton) addGroupButton.classList.remove('editing');
-    if (removeGroupButton) removeGroupButton.classList.remove('editing');
-
     const rollLabelElement = document.querySelector('label[for="roll-name"]');
     if (rollLabelElement) {
         rollLabelElement.textContent = 'Roll Label';
         rollLabelElement.classList.remove('editing');
     }
+
+    // Remove editing class from group name inputs
+    const groupNameInputs = document.querySelectorAll('.dice-group-name-input');
+    groupNameInputs.forEach(input => {
+        input.classList.remove('editing');
+    });
+
+    // Remove editing class from Add Group and Remove Group buttons
+    const addGroupButton = document.getElementById('add-group-button');
+    const removeGroupButton = document.getElementById('remove-group-button');
+    if (addGroupButton) addGroupButton.classList.remove('editing');
+    if (removeGroupButton) removeGroupButton.classList.remove('editing');
 }
 
 function updateRollButtons(rollEntry, rollData) {
@@ -721,10 +729,13 @@ function createRollButton(imageName, rollType, rollGroups, classes, parent) {
 }
 
 function reset() {
-    updateDiceGroupsData();
     document.getElementById("roll-name").value = "";
 
     diceGroupsData.forEach((group, index) => {
+        // Reset group name
+        const groupNameInput = document.getElementById(`group-${index}-name`);
+        if (groupNameInput) groupNameInput.value = "";
+
         diceTypes.forEach((type) => {
             const counter = document.getElementById(
                 `${index}-${type}-counter-value`
@@ -744,7 +755,14 @@ function reset() {
         }
     });
 
-    diceGroupsData.splice(1);
+    // Reset diceGroupsData to contain only one empty group
+    diceGroupsData = [{
+        name: "",
+        diceCounts: Object.fromEntries(diceTypes.map(type => [type, 0]).concat([['mod', 0]]))
+    }];
+
+    // Update the data to ensure consistency between UI and data
+    updateDiceGroupsData();
 }
 
 function disableButtonById(id, disable = true) {

--- a/vault.css
+++ b/vault.css
@@ -321,6 +321,22 @@ body.modal-open {
     pointer-events: auto;
 }
 
+.dice-group-name {
+    margin-bottom: 10px;
+}
+
+.dice-group-name-input {
+    width: 100%;
+    padding: 5px;
+    font-size: 1em;
+}
+
+.dice-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
 .padding-div{
     display: flex;
     align-items: center;

--- a/vault.css
+++ b/vault.css
@@ -10,22 +10,20 @@ html, body {
     user-select: none;
 }
 
-/* NEW CSS PLAYING WITH */
-
 .dice-selection-container {
     display: flex;
     flex-direction: column;
     align-items: center;
 }
+
 .dice-selection{
     margin-bottom: 20px; 
 }
+
 .content-col {
     overflow: auto;  
     max-height: 90vh; 
 }
-
-/* NEW CSS END */
 
 .unselectable{
     user-select: none;
@@ -226,7 +224,6 @@ h1 {
          1px 1px 0 #ffffff;
 }
 
-
 .dice-selection {
     display: flex;
     justify-content: center; 
@@ -238,11 +235,9 @@ h1 {
     z-index: 0;
 }
 
-
 .ts-icon-custom-size {
     font-size: 30%;
 }
-
 
 .plus-sign {
     display: flex;
@@ -275,6 +270,43 @@ h1 {
 
 .delete-roll:hover {
     background-color: #ff0000;
+}
+
+.edit-roll {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    width: 38px;
+    height: 38px;
+    background-color: #868686;
+    color: rgb(0, 0, 0);
+    border-radius: 50%;
+    font-size: 18px;
+    font-weight: bold;
+    margin: 0 5px;
+    margin-left: auto;
+    transition: background-color 0.2s;
+}
+
+.edit-roll:hover {
+    background-color: #4e4e4e;
+}
+
+.saved-roll-entry.editing {
+    background-color: #2c662e; /* Light blue background for the edited roll */
+}
+
+.edit-roll.editing {
+    background-color: #4CAF50; /* Green background for the edit button when editing */
+}
+
+#roll-name.editing {
+    border: 1px solid #ff0000;
+}
+
+label[for="roll-name"].editing {
+    color: #ff0000;
 }
 
 .padding-div{
@@ -315,7 +347,6 @@ h1 {
     margin: 5px 0;
 }
 
-
 .select-list {
     padding: 8px 16px; 
     margin-left: 10px; 
@@ -340,7 +371,6 @@ h1 {
     border-color: var(--ts-color-secondary); 
 }
 
-
 .select-list::-ms-expand {
     display: none; 
 }
@@ -355,7 +385,6 @@ h1 {
     transform: translateY(-50%);
     pointer-events: none;
 }
-
 
 .dice-counter {
     position: relative;
@@ -430,6 +459,12 @@ h1 {
     margin-bottom: 0.8em;
     gap: 2%;
     width: 100%;
+}
+
+.saved-rolls-button-container {
+    display: flex;
+    margin-left: auto;
+
 }
 
 .button-container {

--- a/vault.css
+++ b/vault.css
@@ -325,6 +325,11 @@ body.modal-open {
     font-size: 1em;
 }
 
+.dice-group-name-input.editing,
+#roll-name.editing {
+    border-color: #ff0000;
+}
+
 .dice-row {
     display: flex;
     align-items: center;

--- a/vault.css
+++ b/vault.css
@@ -135,10 +135,6 @@ h1 {
     user-select: none; 
 }
 
-.saved-roll-entry, .roll-button {
-    user-select: none;
-}
-
 .roll-button {
     display: block;
     padding: 5px 10px;
@@ -165,11 +161,11 @@ h1 {
 .row-button{
     flex: 1;
     margin: 0 5px;
-    height: 30px;
+    height: 40px;
 }
 
 .row-button img{
-    height: 30px;
+    height: 40px;
 }
 
 .saved-roll-entry {
@@ -177,10 +173,8 @@ h1 {
     margin-bottom: 5px;
     display: flex;
     flex-direction: column;
-    /* COMMENT: @json, this is what i added to align the title left */
     justify-content: flex-start;
-    /**/
-    align-items: left;
+    align-items: flex-start;
     background-color: var(--ts-button-background);
     font-family: 'OptimusPrinceps', sans-serif;
     padding: 10px;
@@ -337,6 +331,22 @@ body.modal-open {
     justify-content: space-between;
 }
 
+.roll-name-container {
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+}
+
+.roll-name-container label {
+    margin-right: 10px;
+}
+
+#roll-name {
+    flex-grow: 1;
+    padding: 5px;
+    font-size: 1em;
+}
+
 .padding-div{
     display: flex;
     align-items: center;
@@ -371,8 +381,10 @@ body.modal-open {
 
 .roll-entry-label {
     font-weight: bold;
-    text-align: center;
+    text-align: left;
     margin: 5px 0;
+    flex-grow: 1;
+    margin-right: 10px; /* Add some space between the label and buttons */
 }
 
 .select-list {
@@ -491,7 +503,7 @@ body.modal-open {
 
 .saved-rolls-button-container {
     display: flex;
-    margin-left: auto;
+    margin-left: center;
 
 }
 

--- a/vault.css
+++ b/vault.css
@@ -309,6 +309,18 @@ label[for="roll-name"].editing {
     color: #ff0000;
 }
 
+body.modal-open {
+    pointer-events: none;
+}
+
+#modal-overlay {
+    pointer-events: auto;
+}
+
+.overwrite-modal {
+    pointer-events: auto;
+}
+
 .padding-div{
     display: flex;
     align-items: center;

--- a/vault.html
+++ b/vault.html
@@ -107,7 +107,7 @@
                 </div>
             </div>
             <div class="button-container unselectable">
-                <button id="add-group-btn" onclick="addDiceGroup(i)">Add Group</button>
+                <button id="add-group-btn" onclick="addDiceGroup()">Add Group</button>
                 <button id="remove-group-btn" onclick="removeDiceGroup()">Remove Group</button>
             </div>
             

--- a/vault.html
+++ b/vault.html
@@ -73,11 +73,11 @@
             
             <div class="button-container unselectable">
                 <button id="reset-btn" onclick="reset()">Reset</button>
-                <button id="save-btn" onclick="save()">Save</button>
+                <button id="save-btn" onclick="save()">Pin</button>
             </div><br>
 
             <div class="saved-rolls-header">
-                <label class="field-title unselectable">Saved Rolls</label>
+                <label class="field-title unselectable">Pinned Rolls</label>
                 <div id="sort-options-container">
                     <select id="sort-options" class='select-list' onchange="sortSavedRolls()">
                         <option value="newest">Newest</option>
@@ -93,11 +93,11 @@
         </div>
 
         <div class="footer">
-            <button id="save-rolls-button" class="black-button">Save Rolls</button>
+            <button id="save-rolls-button" class="black-button">Save Locally</button>
             
             <i class="ts-icon-character-gamemaster"></i><div style="font-family: 'Enchanted Land', cursive; color: #dddddd; font-size: 0.7em;"> "May the rolls be in your favor"</div>
 
-            <button id="load-rolls-button" class="black-button">Load Rolls</button>
+            <button id="load-rolls-button" class="black-button">Load Saves</button>
         </div>
 
         <script type="text/javascript" src="scripts/globals.js"></script>

--- a/vault.html
+++ b/vault.html
@@ -47,71 +47,16 @@
                 <br>
                 <div class="version">Version: 2.2</div>
             </div>
-            
+
             <br>
 
-            <!-- <div class="content-col">
-                <label class="field-title" for="roll-name">Roll Label</label>
-                <input id="roll-name" type="text" class="roll-input" placeholder="Enter roll label"></input>
+            <div class="roll-name-container">
+                <input type="text" id="roll-name" name="roll-name" placeholder="Enter roll name">
             </div>
-            
-            <br> -->
+
+            <br> 
 
             <div class="content-col-dice">
-                <!-- <div class="dice-selection" id="0">
-                    <div class="dice-group-container">
-                        <div class="dice-group-name">
-                            <input type="text" class="dice-group-name-input" id="0-name" placeholder="Group Name">
-                        </div>
-                        <div class="dice-row">
-                            <div class="dice-counter unselectable" id="0-d4-counter">
-                                <i class="ts-icon-d4 ts-icon-large" onclick="increment('0-d4')" oncontextmenu="decrement('0-d4'); return false;"></i>
-                                <div class="counter-overlay" id="0-d4-counter-value">0</div>
-                                <div class="dice-label">D4</div>
-                            </div>
-
-                            <div class="dice-counter unselectable" id="0-d6-counter">
-                                <i class="ts-icon-d6 ts-icon-large" onclick="increment('0-d6')" oncontextmenu="decrement('0-d6'); return false;"></i>
-                                <div class="counter-overlay" id="0-d6-counter-value">0</div>
-                                <div class="dice-label">D6</div>
-                            </div>
-
-                            <div class="dice-counter unselectable" id="0-d8-counter">
-                                <i class="ts-icon-d8 ts-icon-large" onclick="increment('0-d8')" oncontextmenu="decrement('0-d8'); return false;"></i>
-                                <div class="counter-overlay" id="0-d8-counter-value">0</div>
-                                <div class="dice-label">D8</div>
-                            </div>
-
-                            <div class="dice-counter unselectable" id="0-d10-counter">
-                                <i class="ts-icon-d10 ts-icon-large" onclick="increment('0-d10')" oncontextmenu="decrement('0-d10'); return false;"></i>
-                                <div class="counter-overlay" id="0-d10-counter-value">0</div>
-                                <div class="dice-label">D10</div>
-                            </div>
-
-                            <div class="dice-counter unselectable" id="0-d12-counter">
-                                <i class="ts-icon-d12 ts-icon-large" onclick="increment('0-d12')" oncontextmenu="decrement('0-d12'); return false;"></i>
-                                <div class="counter-overlay" id="0-d12-counter-value">0</div>
-                                <div class="dice-label">D12</div>
-                            </div>
-
-                            <div class="dice-counter unselectable" id="0-d20-counter">
-                                <i class="ts-icon-d20 ts-icon-large" onclick="increment('0-d20')" oncontextmenu="decrement('0-d20'); return false;"></i>
-                                <div class="counter-overlay" id="0-d20-counter-value">0</div>
-                                <div class="dice-label">D20</div>
-                            </div>
-
-                            <div class="plus-sign">
-                                <span>+</span>
-                            </div>
-                            
-                            <div class="dice-counter unselectable" id="0-mod-counter">
-                                <i class="ts-icon-circle-dotted ts-icon-large mod-holder"></i>
-                                <input type="number" class="counter-overlay mod-counter-overlay" id="0-mod-counter-value" value="0" min="-999" max="999" onfocus="this.select()" />
-                                <div class="dice-label">MOD</div>
-                            </div>
-                        </div>
-                    </div>     
-                </div> -->
             </div>
             <div class="button-container unselectable">
                 <button id="add-group-btn" onclick="addDiceGroup()">Add Group</button>

--- a/vault.html
+++ b/vault.html
@@ -50,61 +50,68 @@
             
             <br>
 
-            <div class="content-col">
+            <!-- <div class="content-col">
                 <label class="field-title" for="roll-name">Roll Label</label>
                 <input id="roll-name" type="text" class="roll-input" placeholder="Enter roll label"></input>
             </div>
             
-            <br>
+            <br> -->
 
             <div class="content-col-dice">
-                <div class="dice-selection" id="0">      
-                    <div class="dice-counter unselectable" id="0-d4-counter">
-                        <i class="ts-icon-d4 ts-icon-large" onclick="increment('0-d4')" oncontextmenu="decrement('0-d4'); return false;"></i>
-                        <div class="counter-overlay" id="0-d4-counter-value">0</div>
-                        <div class="dice-label">D4</div>
-                    </div>
+                <!-- <div class="dice-selection" id="0">
+                    <div class="dice-group-container">
+                        <div class="dice-group-name">
+                            <input type="text" class="dice-group-name-input" id="0-name" placeholder="Group Name">
+                        </div>
+                        <div class="dice-row">
+                            <div class="dice-counter unselectable" id="0-d4-counter">
+                                <i class="ts-icon-d4 ts-icon-large" onclick="increment('0-d4')" oncontextmenu="decrement('0-d4'); return false;"></i>
+                                <div class="counter-overlay" id="0-d4-counter-value">0</div>
+                                <div class="dice-label">D4</div>
+                            </div>
 
-                    <div class="dice-counter unselectable" id="0-d6-counter">
-                        <i class="ts-icon-d6 ts-icon-large" onclick="increment('0-d6')" oncontextmenu="decrement('0-d6'); return false;"></i>
-                        <div class="counter-overlay" id="0-d6-counter-value">0</div>
-                        <div class="dice-label">D6</div>
-                    </div>
+                            <div class="dice-counter unselectable" id="0-d6-counter">
+                                <i class="ts-icon-d6 ts-icon-large" onclick="increment('0-d6')" oncontextmenu="decrement('0-d6'); return false;"></i>
+                                <div class="counter-overlay" id="0-d6-counter-value">0</div>
+                                <div class="dice-label">D6</div>
+                            </div>
 
-                    <div class="dice-counter unselectable" id="0-d8-counter">
-                        <i class="ts-icon-d8 ts-icon-large" onclick="increment('0-d8')" oncontextmenu="decrement('0-d8'); return false;"></i>
-                        <div class="counter-overlay" id="0-d8-counter-value">0</div>
-                        <div class="dice-label">D8</div>
-                    </div>
+                            <div class="dice-counter unselectable" id="0-d8-counter">
+                                <i class="ts-icon-d8 ts-icon-large" onclick="increment('0-d8')" oncontextmenu="decrement('0-d8'); return false;"></i>
+                                <div class="counter-overlay" id="0-d8-counter-value">0</div>
+                                <div class="dice-label">D8</div>
+                            </div>
 
-                    <div class="dice-counter unselectable" id="0-d10-counter">
-                        <i class="ts-icon-d10 ts-icon-large" onclick="increment('0-d10')" oncontextmenu="decrement('0-d10'); return false;"></i>
-                        <div class="counter-overlay" id="0-d10-counter-value">0</div>
-                        <div class="dice-label">D10</div>
-                    </div>
+                            <div class="dice-counter unselectable" id="0-d10-counter">
+                                <i class="ts-icon-d10 ts-icon-large" onclick="increment('0-d10')" oncontextmenu="decrement('0-d10'); return false;"></i>
+                                <div class="counter-overlay" id="0-d10-counter-value">0</div>
+                                <div class="dice-label">D10</div>
+                            </div>
 
-                    <div class="dice-counter unselectable" id="0-d12-counter">
-                        <i class="ts-icon-d12 ts-icon-large" onclick="increment('0-d12')" oncontextmenu="decrement('0-d12'); return false;"></i>
-                        <div class="counter-overlay" id="0-d12-counter-value">0</div>
-                        <div class="dice-label">D12</div>
-                    </div>
+                            <div class="dice-counter unselectable" id="0-d12-counter">
+                                <i class="ts-icon-d12 ts-icon-large" onclick="increment('0-d12')" oncontextmenu="decrement('0-d12'); return false;"></i>
+                                <div class="counter-overlay" id="0-d12-counter-value">0</div>
+                                <div class="dice-label">D12</div>
+                            </div>
 
-                    <div class="dice-counter unselectable" id="0-d20-counter">
-                        <i class="ts-icon-d20 ts-icon-large" onclick="increment('0-d20')" oncontextmenu="decrement('0-d20'); return false;"></i>
-                        <div class="counter-overlay" id="0-d20-counter-value">0</div>
-                        <div class="dice-label">D20</div>
-                    </div>
+                            <div class="dice-counter unselectable" id="0-d20-counter">
+                                <i class="ts-icon-d20 ts-icon-large" onclick="increment('0-d20')" oncontextmenu="decrement('0-d20'); return false;"></i>
+                                <div class="counter-overlay" id="0-d20-counter-value">0</div>
+                                <div class="dice-label">D20</div>
+                            </div>
 
-                    <div class="plus-sign">
-                        <span>+</span>
-                    </div>
-                    
-                    <div class="dice-counter unselectable" id="0-mod-counter">
-                        <i class="ts-icon-circle-dotted ts-icon-large mod-holder"></i>
-                        <input type="number" class="counter-overlay mod-counter-overlay" id="0-mod-counter-value" value="0" min="-999" max="999" onfocus="this.select()" />
-                        <div class="dice-label">MOD</div>
-                    </div>
-                </div>
+                            <div class="plus-sign">
+                                <span>+</span>
+                            </div>
+                            
+                            <div class="dice-counter unselectable" id="0-mod-counter">
+                                <i class="ts-icon-circle-dotted ts-icon-large mod-holder"></i>
+                                <input type="number" class="counter-overlay mod-counter-overlay" id="0-mod-counter-value" value="0" min="-999" max="999" onfocus="this.select()" />
+                                <div class="dice-label">MOD</div>
+                            </div>
+                        </div>
+                    </div>     
+                </div> -->
             </div>
             <div class="button-container unselectable">
                 <button id="add-group-btn" onclick="addDiceGroup()">Add Group</button>

--- a/vault.html
+++ b/vault.html
@@ -45,7 +45,7 @@
                 <button id="retrieve-backup-button" onclick="handleRetrieveBackup()">Retrieve Data Backup</button>
                 <br>
                 <br>
-                <div class="version">Version: 2.2</div>
+                <div class="version">Version: 3.0</div>
             </div>
 
             <br>

--- a/vault.html
+++ b/vault.html
@@ -45,7 +45,7 @@
                 <button id="retrieve-backup-button" onclick="handleRetrieveBackup()">Retrieve Data Backup</button>
                 <br>
                 <br>
-                <div class="version">Version: 2.1</div>
+                <div class="version">Version: 2.2</div>
             </div>
             
             <br>
@@ -107,8 +107,8 @@
                 </div>
             </div>
             <div class="button-container unselectable">
-                <button id="add-row-btn" onclick="addDiceGroup()">Add Group</button>
-                <button id="remove-row-btn" onclick="removeDiceGroup()">Remove Group</button>
+                <button id="add-group-btn" onclick="addDiceGroup(i)">Add Group</button>
+                <button id="remove-group-btn" onclick="removeDiceGroup()">Remove Group</button>
             </div>
             
             <div class="button-container unselectable">

--- a/vault.html
+++ b/vault.html
@@ -119,11 +119,11 @@
             </div>
             
             <div class="button-container unselectable">
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'normal')"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'advantage')"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'disadvantage')"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'best-of-three')"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
-                <button class="rolling-button" onclick="rollsModule.roll(null, 'crit-dice')"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
+                <button class="rolling-button" onclick="rollsModule.roll('normal')"><img class="roll-type-image" src="./images/icons/rolling.png" alt="roll dice"/><br/>Roll</button>
+                <button class="rolling-button" onclick="rollsModule.roll('advantage')"><img class="roll-type-image" src="./images/icons/advantage.png" alt="advantage"/><br/>Advantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll('disadvantage')"><img class="roll-type-image" src="./images/icons/disadvantage.png" alt="disadvantage"/><br/>Disadvantage</button>
+                <button class="rolling-button" onclick="rollsModule.roll('best-of-three')"><img class="roll-type-image" src="./images/icons/best-of-three.png" alt="best of three"/><br/>Best of 3</button>
+                <button class="rolling-button" onclick="rollsModule.roll('crit-dice')"><img class="roll-type-image" src="./images/icons/crit.png" alt="critical hit"/><br/>Critical</button>
             </div>
             
             <div class="button-container unselectable">


### PR DESCRIPTION
3.0
- New feature: Named roll groups! Previously we expanded functionality to let you roll independent roll groups. Unfortunately, all the groups shared the same name according to Talespire. This has been resolved and all roll groups can have their own unique name. If no name is provided, it defaults to "Group 1", "Group 2", etc. This caused another change in the data structure so rolls from old versions will not roll forward from prior versions of Dice Vault.
- Edit buttons on saved rolls allows for modifying a saved roll without deleting it!
- Buttons have been renamed to clarify their purpose. Pin a roll only stores the roll for that play session. Save Locally stores your pinned rolls into ./localstorage. These terms will be the new nomenclature going forward. "Pin" is temporary, "Save" is permanent.

I still have the 1.3  >> 2.0 upgrade code in there but I decided to leave it. It's not doing any damage leaving it there, worst case a user will fail to upgrade from 2.1 to 3.0 which I already published guidance in the readme that this is no longer supported as I don't want to create custom upgrade code every update.