### PR TITLE
Exp/advantage disadvantage rework

### DIFF
--- a/scripts/RollManager.js
+++ b/scripts/RollManager.js
@@ -663,19 +663,23 @@ const rollManager = (function () {
      *
      * This function takes a roll object and a boolean indicating whether the roll is
      * under advantage or disadvantage conditions. It divides the roll's results into
-     * two equal sets. If the number of results groups is less than 2 or not even, it
-     * returns the original results groups. It then calculates the sum of each set.
-     * Under advantage conditions, it returns the set with the higher sum; under disadvantage
-     * conditions, it returns the set with the lower sum.
+     * two equal sets and evaluates each group position independently. For each position,
+     * it compares the corresponding group from set 1 vs set 2 and picks the winner
+     * individually — meaning the final result may mix groups from both rolls. Under
+     * advantage conditions, it picks the group with the higher sum at each position;
+     * under disadvantage conditions, it picks the group with the lower sum.
+     *
+     * If the number of results groups is less than 2 or not even, it returns the
+     * original results groups unchanged.
      *
      * @param {Object} roll             - An object representing a roll, which contains an array of
      *                                    results groups.
      * @param {boolean} isAdvantage     - A boolean indicating if the roll is under advantage (true)
      *                                    or disadvantage (false) conditions.
      *
-     * @returns {Promise<Array>} A promise that resolves to an array representing the
-     *                           set of roll results with either the highest sum (advantage)
-     *                           or the lowest sum (disadvantage).
+     * @returns {Promise<Array>} A promise that resolves to an array of per-position winning
+     *                           groups, each independently chosen for the highest sum (advantage)
+     *                           or lowest sum (disadvantage).
      */
     async function handleAdvantageDisadvantageRoll(roll, isAdvantage) {
         if (
@@ -685,25 +689,21 @@ const rollManager = (function () {
             return roll.resultsGroups;
         }
 
-        let startingIndexOfSecondSetOfGroups = roll.resultsGroups.length / 2;
+        let half = roll.resultsGroups.length / 2;
+        let firstSetOfGroups = roll.resultsGroups.slice(0, half);
+        let secondSetOfGroups = roll.resultsGroups.slice(half);
 
-        let firstSetOfGroups = roll.resultsGroups.slice(
-            0,
-            startingIndexOfSecondSetOfGroups
-        );
+        let chosenGroups = [];
 
-        let secondSetOfGroups = roll.resultsGroups.slice(
-            startingIndexOfSecondSetOfGroups
-        );
+        for (let i = 0; i < half; i++) {
+            let sumA = await TS.dice.evaluateDiceResultsGroup(firstSetOfGroups[i]);
+            let sumB = await TS.dice.evaluateDiceResultsGroup(secondSetOfGroups[i]);
 
-        let sumOfFirstSet = await getSumOfRollResultsGroups(firstSetOfGroups);
-        let sumOfSecondSet = await getSumOfRollResultsGroups(secondSetOfGroups);
+            let pickFirst = isAdvantage ? (sumA >= sumB) : (sumA <= sumB);
+            chosenGroups.push(pickFirst ? firstSetOfGroups[i] : secondSetOfGroups[i]);
+        }
 
-        let chosenSet = (isAdvantage ?
-            (sumOfFirstSet >= sumOfSecondSet ? firstSetOfGroups : secondSetOfGroups) :
-            (sumOfFirstSet <= sumOfSecondSet ? firstSetOfGroups : secondSetOfGroups));
-
-        return chosenSet;
+        return chosenGroups;
     }
 
     /**

--- a/scripts/RollManager.js
+++ b/scripts/RollManager.js
@@ -533,6 +533,19 @@ const rollManager = (function () {
                                 otherGroups = applyCritBehaviorToRollResultsGroup(otherGroups, rollInfo.critBehavior);
                             }
 
+                            // Check for exploding dice in non-duality groups only
+                            // Duality dice (Hope/Fear) should never explode, but other dice in the roll can
+                            const explodingEnabled = fetchSetting('enable-exploding-dice');
+                            if (explodingEnabled && otherGroups.length > 0) {
+                                const increaseSize = fetchSetting('increase-exploded-die-size');
+                                const explosionData = checkForExplosions(otherGroups, increaseSize);
+                                if (explosionData.hasExplosions) {
+                                    console.log("Explosions detected in non-duality groups, starting explosion chain");
+                                    startExplosionChain(roll.rollId, rollInfo, otherGroups, explosionData, [winningGroup]);
+                                    return;
+                                }
+                            }
+
                             // Include both the duality result AND any other dice groups
                             // The duality groups are totalled together, but other groups remain separate
                             resultGroups = [winningGroup, ...otherGroups];
@@ -548,7 +561,7 @@ const rollManager = (function () {
 
                         // Check for exploding dice BEFORE applying crit behavior
                         const explodingEnabled = fetchSetting('enable-exploding-dice');
-                        if (explodingEnabled && !isDualityRoll) {
+                        if (explodingEnabled) {
                             const increaseSize = fetchSetting('increase-exploded-die-size');
                             const explosionData = checkForExplosions(resultGroups, increaseSize);
                             if (explosionData.hasExplosions) {
@@ -1068,7 +1081,7 @@ const rollManager = (function () {
      * @param {Array<Object>} resultGroups - The result groups from the parent roll
      * @param {Object} explosionData - Output from checkForExplosions()
      */
-    function startExplosionChain(parentRollId, rollInfo, resultGroups, explosionData) {
+    function startExplosionChain(parentRollId, rollInfo, resultGroups, explosionData, prependedGroups = []) {
         activeExplosionChains[parentRollId] = {
             parentRollId: parentRollId,
             rollType: rollInfo.type,
@@ -1078,7 +1091,8 @@ const rollManager = (function () {
             maxExplosionDepth: 100,
             accumulatedResultGroups: [resultGroups],
             pendingExplosionData: explosionData,
-            increaseSize: fetchSetting('increase-exploded-die-size')
+            increaseSize: fetchSetting('increase-exploded-die-size'),
+            prependedGroups: prependedGroups
         };
 
         console.log(`Starting explosion chain for parent roll ${parentRollId}, round 1`);
@@ -1186,7 +1200,9 @@ const rollManager = (function () {
                 chain.critBehavior
             );
 
-            await displayResults(finalResults, parentRollId);
+            // Prepend pre-processed groups (e.g., duality result) before displaying
+            const displayGroups = [...(chain.prependedGroups || []), ...finalResults];
+            await displayResults(displayGroups, parentRollId);
             console.log(`Explosion chain finalized for parent roll ${parentRollId}`);
         } catch (error) {
             console.error(`Error finalizing explosion chain for ${parentRollId}:`, error);


### PR DESCRIPTION
This PR includes a few changes, all bugs reported by Roger
- Advantage/Disadvantage was evaluating the total of the rolls, not each group against its counterpart group which is the more proper way of doing adv./dis.
- Exploding dice now apply to Daggerheart rolls. Previously explosions were ignored in this scenario due to misunderstanding Daggerheart ruleset.